### PR TITLE
Fixing cutout wcs bug

### DIFF
--- a/changes/8.snappl.rst
+++ b/changes/8.snappl.rst
@@ -1,0 +1,1 @@
+Fixes a bug where cutouts had no wcs by passing self.get_wcs() directly into Astropy's cutout2D.

--- a/snappl/image.py
+++ b/snappl/image.py
@@ -296,6 +296,7 @@ class OpenUniverse2024FITSImage( Image ):
                 self._wcs = AstropyWCS( hdul[1].header )
         return self._wcs
 
+
     def _get_header(self):
         """Get the header of the image."""
         if self._header is None:
@@ -371,13 +372,14 @@ class OpenUniverse2024FITSImage( Image ):
         Lager.debug(f'Cutting out at {x , y}')
         data, noise, flags = self.get_data('all')
         astropy_cutout = Cutout2D(data, loc, size=(ysize, xsize), # Astropy asks for this order. Beats me. -Cole
-                                   mode='strict')
+                                   mode='strict', wcs=self.get_wcs())
         astropy_noise = Cutout2D(noise, loc, size=(ysize, xsize),
-                                   mode='strict')
+                                   mode='strict', wcs=self.get_wcs())
 
         snappl_cutout = self.__class__(self.inputs.path, self.inputs.exposure, self.inputs.sca)
         snappl_cutout._data = astropy_cutout.data
         snappl_cutout._wcs = astropy_cutout.wcs
+        Lager.debug(f'Giving cutout a new WCS of {astropy_cutout.wcs}')
         snappl_cutout._noise = astropy_noise.data
         snappl_cutout._is_cutout = True
 
@@ -397,7 +399,7 @@ class OpenUniverse2024FITSImage( Image ):
             Width of the cutout in pixels.
         ysize : int
             Height of the cutout in pixels. If None, set to xsize.
-            
+
         Returns
         -------
         cutout : snappl.image.Image

--- a/snappl/image.py
+++ b/snappl/image.py
@@ -296,7 +296,6 @@ class OpenUniverse2024FITSImage( Image ):
                 self._wcs = AstropyWCS( hdul[1].header )
         return self._wcs
 
-
     def _get_header(self):
         """Get the header of the image."""
         if self._header is None:
@@ -379,7 +378,6 @@ class OpenUniverse2024FITSImage( Image ):
         snappl_cutout = self.__class__(self.inputs.path, self.inputs.exposure, self.inputs.sca)
         snappl_cutout._data = astropy_cutout.data
         snappl_cutout._wcs = astropy_cutout.wcs
-        Lager.debug(f'Giving cutout a new WCS of {astropy_cutout.wcs}')
         snappl_cutout._noise = astropy_noise.data
         snappl_cutout._is_cutout = True
 


### PR DESCRIPTION
Previously, Astropy cutout2d was not taking in wcs as an input, so the output wcs was None. I have now changed it to take in the image's WCS via self.get_wcs().