### PR TITLE
PSF updates : off-center PSFs, photutils ImagePSFs

### DIFF
--- a/.github/workflows/run_snappl_tests.yml
+++ b/.github/workflows/run_snappl_tests.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COMPOSE_FILE: snappl/tests/docker-compose.yaml
+      GITHUB_SKIP: 1
 
     steps:
       - name: Dump docker logs on failure

--- a/.github/workflows/run_snappl_tests.yml
+++ b/.github/workflows/run_snappl_tests.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COMPOSE_FILE: snappl/tests/docker-compose.yaml
-      GITHUB_SKIP: 1
 
     steps:
       - name: Dump docker logs on failure

--- a/changes/31.feature.rst
+++ b/changes/31.feature.rst
@@ -1,0 +1,1 @@
+Offcenter PSFs in get_stamp(); test for ou24PSF; photutilsImagePSF

--- a/experimentation/README.md
+++ b/experimentation/README.md
@@ -1,1 +1,1 @@
-This directory is for test script and such that aren't really part of the snappl package, but that might be useful to archive for future reference.
+This directory is for test scripts and such that aren't really part of the snappl package, but that might be useful to archive for future reference.

--- a/experimentation/README.md
+++ b/experimentation/README.md
@@ -1,0 +1,1 @@
+This directory is for test script and such that aren't really part of the snappl package, but that might be useful to archive for future reference.

--- a/experimentation/play_with_photutils.py
+++ b/experimentation/play_with_photutils.py
@@ -97,6 +97,13 @@ print( f"Fit flux of 100000-flux star for sigma = 0.42: {phot['flux_fit'][0]}; "
        f"(x,y)=({phot['x_fit'][0]}, {phot['y_fit'][0]}" )
 
 
+# RESULTS OF A RUN:
+#    root@655734bb3457:/snappl/experimentation# python play_with_photutils.py
+#    1.2-sigma PSF clip sums to 1.0000000000018092
+#    0.42-sigma PSF clip sums to 1.1267689222010988
+#    Fit flux of 100000-flux star for sigma = 1.2: 99833.32184334665; (x,y)=(511.00130567398907, 510.99895105013127
+#    Fit flux of 100000-flux star for sigma = 0.42: 100005.90585339173; (x,y)=(511.0002593061244, 511.0001099684552
+#
 # CONCLUSION:
 #
 # For PSFs whose FWHM is less than ~2 pixels on the original

--- a/experimentation/play_with_photutils.py
+++ b/experimentation/play_with_photutils.py
@@ -1,0 +1,102 @@
+import numpy as np
+
+from astropy.io import fits
+import astropy.table
+import photutils.psf
+
+# You probably want stampsize = 2 * 5 * 2√(2ln2) * max(sigmax,sigmay)
+def make_gaussian_psf( oversamp=3, sigmax=1.2, sigmay=None, stampsize=None, x0=511, y0=511 ):
+    if oversamp % 2 != 1:
+        raise ValueError( "Please use an odd oversampling factor." )
+
+    sigmay = sigmax if sigmay is None else sigmay
+
+    # Default to a stamp size of 2 * 5 FHWMs (so "radius" 5 FWHM)
+    if stampsize is None:
+        stampsize = int( np.ceil( 10 * 2.35482 * max( sigmax, sigmay ) ) )
+        stampsize += 1 if stampsize % 2 ==0 else 0
+    if stampsize % 2 != 1:
+        raise ValueError( "stampsize must be odd" )
+
+    oversampsize = oversamp * stampsize
+    ctr = oversampsize // 2
+    xvals = np.arange( -ctr, ctr+1 )
+    yvals = np.arange( -ctr, ctr+1 )
+    ovsigmax = oversamp * sigmax
+    ovsigmay = oversamp * sigmay
+    data = np.exp( -( xvals[np.newaxis,:]**2 / ( 2. * ovsigmax**2 ) +
+                      yvals[:,np.newaxis]**2 / ( 2. * ovsigmay**2 ) ) )
+    # photutils expects an oversampled PSF to be normalized like this:
+    data /= data.sum() / ( oversamp**2 )
+
+    psf = photutils.psf.ImagePSF( data, flux=1, x_0=x0, y_0=y0, oversampling=oversamp )
+
+    return psf
+
+
+def make_fake_image( skynoise=10., starflux=100000., nx=1024, ny=1024, x=511, y=511,
+                     oversamp=3, sigmax=1.2, sigmay=None, stampsize=None ):
+    rng = np.random.default_rng()
+    image = rng.normal( scale=skynoise, size=(ny, nx) )
+
+    xc = int( np.floor( x + 0.5 ) )
+    yc = int( np.floor( y + 0.5 ) )
+
+    psf = make_gaussian_psf( oversamp=oversamp, sigmax=sigmax, sigmay=sigmay, stampsize=stampsize, x0=x, y0=y )
+    xmin = -( stampsize // 2 ) + xc
+    xmax = xmin + stampsize
+    ymin = -( stampsize // 2 ) + yc
+    ymax = ymin + stampsize
+    # WORRY : did I get the x, y order right?
+    xvals, yvals = np.meshgrid( np.arange( xmin, xmax ), np.arange( ymin, ymax ) )
+    # Not adding poisson noise to our PSF; deal
+    image[ ymin:ymax, xmin:xmax ] += psf( xvals, yvals ) * starflux
+
+    return image, psf
+
+# **********************************************************************
+# Actual experiments
+
+# Have a plenty-sampled PSF with a sigma of 1.2, stampsize 29, oversampling by 3)
+psf = make_gaussian_psf( oversamp=3, sigmax=1.2, stampsize=29, x0=511, y0=511 )
+xvals = np.arange( 511 - (29//2), 511 + (29//2) + 1 )
+yvals = np.arange( 511 - (29//2), 511 + (29//2) + 1 )
+xvals, yvals = np.meshgrid( xvals, yvals )
+print( f"1.2-sigma PSF clip sums to {psf( xvals, yvals ).sum()}" )
+
+# Have a PSF with a 1-pixel FWHM (so σ = 1/(2√(2ln2)) = 0.42 ), stampsize 11, oversamped 5x
+psf = make_gaussian_psf( oversamp=5, sigmax=0.42, stampsize=11, x0=511, y0=511 )
+xvals = np.arange( 511 - (29//2), 511 + (29//2) + 1 )
+yvals = np.arange( 511 - (29//2), 511 + (29//2) + 1 )
+xvals, yvals = np.meshgrid( xvals, yvals )
+print( f"0.42-sigma PSF clip sums to {psf( xvals, yvals ).sum()}" )
+
+
+# Now let's try some PSF photometry and see how it does
+# We are always going to use sky noise 10, and just not bother
+#  with star poisson noise for now (because we're naughty)
+
+# First with the happy big star
+image, psf = make_fake_image( oversamp=3, sigmax=1.2, stampsize=29 )
+noiseim = np.full_like( image, 10. )
+fit_shape = ( 15, 15 )
+photor = photutils.psf.PSFPhotometry( psf, fit_shape )
+phot = photor( image, error=noiseim,
+               init_params=astropy.table.Table( { 'x_init': [510.5], 'y_init': [513.], 'flux_init': [95000] } ) )
+print( f"Fit flux of 100000-flux star for sigma = 1.2: {phot['flux_fit'][0]}; "
+       f"(x,y)=({phot['x_fit'][0]}, {phot['y_fit'][0]}" )
+
+# Now with a little star
+image, psf = make_fake_image( oversamp=5, sigmax=0.42, stampsize=11 )
+fit_shape = ( 7, 7 )
+photor = photutils.psf.PSFPhotometry( psf, fit_shape )
+phot = photor( image, error=noiseim,
+               init_params=astropy.table.Table( { 'x_init': [511.2], 'y_init': [510.9], 'flux_init': [95000] } ) )
+print( f"Fit flux of 100000-flux star for sigma = 0.42: {phot['flux_fit'][0]}; "
+       f"(x,y)=({phot['x_fit'][0]}, {phot['y_fit'][0]}" )
+import pdb; pdb.set_trace()
+pass
+
+
+
+

--- a/experimentation/play_with_photutils.py
+++ b/experimentation/play_with_photutils.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from astropy.io import fits
 import astropy.table
 import photutils.psf
+
 
 # You probably want stampsize = 2 * 5 * 2√(2ln2) * max(sigmax,sigmay)
 def make_gaussian_psf( oversamp=3, sigmax=1.2, sigmay=None, stampsize=None, x0=511, y0=511 ):
@@ -54,6 +54,7 @@ def make_fake_image( skynoise=10., starflux=100000., nx=1024, ny=1024, x=511, y=
 
     return image, psf
 
+
 # **********************************************************************
 # Actual experiments
 
@@ -91,12 +92,20 @@ image, psf = make_fake_image( oversamp=5, sigmax=0.42, stampsize=11 )
 fit_shape = ( 7, 7 )
 photor = photutils.psf.PSFPhotometry( psf, fit_shape )
 phot = photor( image, error=noiseim,
-               init_params=astropy.table.Table( { 'x_init': [511.2], 'y_init': [510.9], 'flux_init': [95000] } ) )
+               init_params=astropy.table.Table( { 'x_init': [511.2], 'y_init': [510.9], 'flux_init': [120000] } ) )
 print( f"Fit flux of 100000-flux star for sigma = 0.42: {phot['flux_fit'][0]}; "
        f"(x,y)=({phot['x_fit'][0]}, {phot['y_fit'][0]}" )
-import pdb; pdb.set_trace()
-pass
 
 
-
-
+# CONCLUSION:
+#
+# For PSFs whose FWHM is less than ~2 pixels on the original
+# image, the stamps you get from the __call__ method of a photutils
+# ImagePSF are not properly normalize.  (Interestingly, they are too big
+# by the same factor that lanczos4 interpolation gives....)  However,
+# photutils PSFPhotometry works in such a way that it takes this into
+# account (...or just doesn't use __call__) and produces reliable results.
+#
+# Which is all well and good if you just want to use PSFPhotometry, but
+# if you need thumbnails for other purposes (e.g. schene modelling),
+# that is very sad.

--- a/snappl/psf.py
+++ b/snappl/psf.py
@@ -659,7 +659,7 @@ class OversampledImagePSF( PSF ):
     PSF is intrnsically undersampled, that is, on the original image the
     FWHM is not at least a couple of pixels.  (TODO: explore how the
     algorithm does with PSFex-extracted PSFs on undersampled data, since
-    the algorithm here was written for and tested with PSFex PSFs.)
+    the algorithm here was written for and tested with PSFex PSFs.)  See Issue #30.
 
     """
 

--- a/snappl/psf.py
+++ b/snappl/psf.py
@@ -26,7 +26,11 @@ class PSF:
 
     """
 
-    # Thought required: how to deal with oversampling.
+    # Thought required: how to deal with oversampling.  Right now, the
+    # OversampledImagePSF and photutilsImagePSF subclasses provide a
+    # property or method to access the single internally stored
+    # oversampled image.  Should there be a general interface for
+    # getting access to oversampled PSFs?
 
     def __init__( self, called_from_get_psf_object=False, *args, **kwargs ):
         """Don't call this or the constructor of a subclass directly, call PSF.get_psf_object().

--- a/snappl/tests/base_testimagepsf.py
+++ b/snappl/tests/base_testimagepsf.py
@@ -1,0 +1,360 @@
+import pytest
+import time
+
+import numpy as np
+import scipy
+from astropy.io import fits
+
+from snpit_utils.logger import SNLogger
+
+
+# This is a test class for tests of image-based PSFs that should all return
+# the same results.  The actual classes that instantiate and make the actual
+# tests run are (as of this writing) TestOversampledImagePSF and TestPhotutilsImagePSF.
+class BaseTestImagePSF:
+    __psfclass__ = object
+
+    def test_create( self, testpsf ):
+        assert isinstance( testpsf, self.__psfclass__ )
+        assert testpsf._data.sum() == pytest.approx( 1., rel=1e-9 )
+        # data array was 77×77, we are oversampled by 3x, so nominally
+        #  it's 25.7×25.7 on the image.  But, the array size is an integer,
+        #  and it floors, so we should get 25
+        assert testpsf.stamp_size == 25
+        assert testpsf.clip_size == 25
+        assert testpsf.oversample_factor == 3
+        assert testpsf.x == 3832.
+        assert testpsf.y == 255.
+        loaded = np.load( 'psf_test_data/testpsfarray.npz' )
+        arr = loaded['args']
+        assert np.all( arr / arr.sum() == testpsf.oversampled_data )
+        # TODO : test that normalize=False works
+
+        @pytest.mark.skip( reason="Comment out the skip to write some files for visual inspection" )
+        def test_interactive_write_stamp_to_fits_for_visual_inspection( self, testpsf ):
+            fits.writeto( 'test_deleteme_orig.fits', testpsf._data, overwrite=True )
+            fits.writeto( 'test_deleteme_resamp.fits', testpsf.get_stamp(), overwrite=True )
+
+    def make_psf_for_test_stamp( self, x=1023, y=511, oversamp=3, sigmax=1.2, sigmay=None ):
+        """Create an oversampled PSF with a Gaussian profile centered at (x, y)
+
+        Exactly what that means in terms of stored data will be different for different
+        PSF subclasses.  However, in all cases, it should give consistent get_stamp
+        behavior.
+
+        Parameters
+        ----------
+          x, y : float, float
+             The position on the source image where the PSF is found
+
+          oversamp : integer
+             The oversampling factor.  (Some subclasses,
+             e.g. OversampledImagePSF, can handle a float oversamp, but
+             some, e.g. photutilsImagePSF, can't.)
+
+          sigmax : float
+             1σ width in original image pixels of the Gaussian profile
+
+          sigmay : float
+             1σ width in original image pixels of the Gaussian profile
+             along the y axis.  Set to sigmax if not passed.
+
+        Returns
+        -------
+           psf, datacx, datacy
+
+           psf is an object that is of the right subclass of PSF for the
+           test being run
+
+           (datacx, datacy) are the expected position of the center of
+           mass of the psf on self.oversampled_data.  This will be
+           different for different subclasses.
+        """
+
+        # Make a 3x oversampled PSF that's a gaussian with sigma 1.2 (in
+        # image pixel units, not oversampled units).  2√(2ln2)*1.2 = FWHM of
+        # 2.83, so for a radius of 5 FWHMs (to be really anal), we want a
+        # 29×29 stamp in image units.
+        #
+        # 3× oversampled means an 87×87 data array.  87 // 2 = 43
+        # 5× oversampled means a 145×145 data array.  145 // 2 = 72
+        raise NotImplementedError( f"{self.__class__.__name} needs to implement make_psf_for_test_stamp" )
+
+    def run_test_get_stamp_orientation( self, oversamp=3, sigmax=1.2, sigmay=2.4 ):
+        psf, _, _ = self.make_psf_for_test_stamp( oversamp=oversamp, sigmax=sigmax, sigmay=sigmay )
+        clip = psf.get_stamp()
+        assert clip.sum() == pytest.approx( 1., abs=0.005 )
+        cy, cx = scipy.ndimage.center_of_mass( clip )
+        assert cy == pytest.approx( 14., abs=0.01 )
+        assert cx == pytest.approx( 14., abs=0.01 )
+
+    # "centered" here means the original PSF is centered; we're going to
+    #   render it offset
+    def run_test_get_stamp_centered_oversampled( self, oversamp=3, sigma=1.2 ):
+        psf, _, _ = self.make_psf_for_test_stamp( oversamp=oversamp, sigmax=sigma )
+
+        # If we just get_stamp(), we should get a 29×29 image centered on the middle
+        # We don't actually really expect the stamp to be exactly expectedgauss, because
+        #   the interpolation in get_stamp() is more sophisticated than just "evaluate
+        #   the gaussian at the point".  We should be oversampled enough, though, that
+        #   it's damn close.
+        clipx = np.arange( -14, 15 )
+        clipy = np.arange( -14, 15 )
+        expectedgauss = np.exp( -( clipx[np.newaxis,:]**2 + clipy[:,np.newaxis]**2 ) / ( 2. * sigma**2 ) )
+        expectedgauss /= expectedgauss.sum()
+        clip = psf.get_stamp()
+        assert clip.shape == ( 29, 29 )
+        assert clip.sum() == pytest.approx( 1, abs=0.005 )
+        # Doing an absolute, not a relative, comparison because where the gaussian is
+        #   approximately zero, we don't need it to be identically 0
+        assert np.all( clip == pytest.approx( expectedgauss, abs=0.001 / ( 29*29 ) ) )
+
+        # Render a bunch that are offset and make sure they center up where
+        # expected
+
+        # When the relative position is offset by an integer from the place
+        #   we evaluted the pixel at ((1023, 511) in this case), the PSF
+        #   should still be centered on the center pixel of the image.
+        # NOTICE : when the fractional part is exactly 0.5, the PSF is
+        #   centered down and to the left of the center pixel of the clip.
+        #   This is as documented in snappl.psf.PSF.get_stamp
+        relpos = [ -2.5, -1.8, -1.4, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 1.0, 1.4,   1.8,  2.5 ]
+        ctrexp = [ 13.5, 14.2, 13.6,   14., 14.2, 13.9, 14., 14.1, 13.8, 14., 14.4, 13.8, 13.5 ]
+        # relpos = [ -1.8, -1.4, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 1.0, 1.4,   1.8 ]
+        # ctrexp = [ 14.2, 13.6,   14., 14.2, 13.9, 14., 14.1, 13.8, 14., 14.4, 13.8 ]
+
+        for xrel, xctr in zip( relpos, ctrexp ):
+            for yrel, yctr in zip( relpos, ctrexp ):
+                clip = psf.get_stamp( 1023 + xrel, 511 + yrel )
+                assert clip.sum() == pytest.approx( 1, abs=0.005 )
+                assert clip.shape == ( 29, 29 )
+                cy, cx = scipy.ndimage.center_of_mass( clip )
+                assert cx == pytest.approx( xctr, abs=0.01 )
+                assert cy == pytest.approx( yctr, abs=0.01 )
+
+        # Now try the case where we pass x0 and y0 to get_stamp.
+
+        # A handful of specific cases with non-None x0 and y0 to help the
+        #   writer of this test think about all the upcoming for loops.
+
+        # First case: we have a PSF that we want centered three pixels up
+        #   and to the right.  We'll pass x0 and y0 as (1023, 511) (which is
+        #   the default), and then give x and y as 1026 and 514.  This is *different*
+        #   from x=1026, y=514, x0=None, y=None; in that case the PSF would be
+        #   centered, because it would determine a different x0 and y0 from what
+        #   we pass in this example.
+
+        clip = psf.get_stamp( 1026., 514., x0=1023, y0=511 )
+        assert clip.sum() == pytest.approx( 1., abs=0.005 )
+        assert clip.shape == ( 29, 29 )
+        cy, cx = scipy.ndimage.center_of_mass( clip )
+        assert cx == pytest.approx( 14.+3., abs=0.01 )
+        assert cy == pytest.approx( 14.+3., abs=0.01 )
+        # Uncomment for visual debugging
+        # fits.writeto( "test_get_stamp_centered_oversampled_1.fits", clip, overwrite=True )
+
+        # Second case: we're going to put the psf at its standard position
+        # of 1023, 511, but then we want the center of the clip to
+        # correspond to 1022, 512 on the image.  So, the PSF should be one
+        # pixel to the right and one pixel down.
+
+        clip = psf.get_stamp( 1023., 511., x0=1022, y0=512 )
+        assert clip.sum() == pytest.approx( 1., abs=0.005 )
+        assert clip.shape == ( 29, 29 )
+        cy, cx = scipy.ndimage.center_of_mass( clip )
+        assert cx == pytest.approx( 14.+1., abs=0.01 )
+        assert cy == pytest.approx( 14.-1., abs=0.01 )
+        # Uncomment for visual debugging
+        # fits.writeto( "test_get_stamp_centered_oversampled_2.fits", clip, overwrite=True )
+
+        # Third case: if we just ask for (x=1023.5, y=511.5), we'll get a
+        # PSF centered down and to the left of the center of the clip,
+        # because of the whole floor thing.  However, if we also give
+        # x0=1023, y0=511, then we should get a PSF centered up and to the
+        # right.
+
+        clip = psf.get_stamp( 1023.5, 511.5 )
+        assert clip.sum() == pytest.approx( 1., abs=0.005 )
+        assert clip.shape == ( 29, 29 )
+        cy, cx = scipy.ndimage.center_of_mass( clip )
+        assert cx == pytest.approx( 14.-0.5, abs=0.01 )
+        assert cy == pytest.approx( 14.-0.5, abs=0.01 )
+        # Uncomment for visual debugging
+        # fits.writeto( "test_get_stamp_centered_oversampled_3.fits", clip, overwrite=True )
+        clip = psf.get_stamp( 1023.5, 511.5, x0=1023, y0=511 )
+        assert clip.sum() == pytest.approx( 1., abs=0.005 )
+        assert clip.shape == ( 29, 29 )
+        cy, cx = scipy.ndimage.center_of_mass( clip )
+        assert cx == pytest.approx( 14.+0.5, abs=0.01 )
+        assert cy == pytest.approx( 14.+0.5, abs=0.01 )
+        # Uncomment for visual debugging
+        # fits.writeto( "test_get_stamp_centered_oversampled_4.fits", clip, overwrite=True )
+
+        # Test a whole bunch in a four-loop.  When off is None then we
+        #   expect the PSF to be centered on the clip at xctr, yctr (pulled
+        #   from the ctrpos array), just as in tests above where we didn't
+        #   pass x0 and y0.  Otherwise, it depends on both x and x0 (or y
+        #   and y0 as appropriate).
+        relpos = [ -2.5, -0.8,  0.,  0.1,  1.4,  1.5 ]
+        ctrpos = [ 13.5, 14.2, 14., 14.1, 14.4, 13.5 ]
+        off = [ -15, -1, 0, None, 3, 12 ]
+        numnear = 0
+        numnearish = 0
+        numnotnear = 0
+        punted = 0
+        for xrel, xctr in zip( relpos, ctrpos ):
+            for yrel, yctr in zip( relpos, ctrpos ):
+                for xoff in off:
+                    x0 = 1023 + xoff if xoff is not None else None
+                    xpeak = 14. + xrel - xoff if xoff is not None else xctr
+                    for yoff in off:
+                        y0 = 511 + yoff if yoff is not None else None
+                        ypeak = 14. + yrel - yoff if yoff is not None else yctr
+
+                        clip = psf.get_stamp( 1023+xrel, 511+yrel, x0=x0, y0=y0 )
+                        assert clip.shape == ( 29, 29 )
+                        # ****
+                        # For visual debugging.  Warning: writes a metric butt-ton of images.
+                        # fits.writeto( f'deteleme_{xrel}_{yrel}_{xoff}_{yoff}.fits', clip, overwrite=True )
+                        # ****
+
+                        # If xpeak or ypeak is too close to the edge, then we don't
+                        #   expect the sum to be 1, because flux will have slopped
+                        #   off of the edge of the clip.  Also, finding the
+                        #   center is fraught; scipy.ndiamge.center_of_mass won't
+                        #   give us the center, because all the missing flux is
+                        #   going to make the formal centroid offset towards
+                        #   the center from the peak.  In that case, satisfy
+                        #   ourself with making sure that the nominal peak
+                        #   pixel is brighter than its neighbors.  (Well...
+                        #   except when the fractional part relpos is 0.5, and
+                        #   then we look at the two (or four) brightest pixels.)
+                        nearishedge = ( xpeak < 3. ) or ( xpeak > 25. ) or ( ypeak < 3. ) or ( ypeak > 25. )
+                        nearedge = ( ( ( xpeak < 2. ) or ( xpeak > 26. ) or ( ypeak < 2. ) or ( ypeak > 26. ) )
+                                     or
+                                     ( ( ( xpeak < 3. ) or ( xpeak > 25. ) )
+                                       and
+                                       ( ( ypeak < 3. ) or ( ypeak > 25. ) )
+                                      )
+                                    )
+                        if nearedge:
+                            numnear += 1
+                            assert clip.sum() < 0.98
+                            ixpeak = int( np.floor( xpeak + 0.5 ) )
+                            iypeak = int( np.floor( ypeak + 0.5 ) )
+                            # We're just gonna punt if the peak is off of the edge of the image
+                            if ( iypeak >= 1 ) and ( iypeak <= 27 ) and ( ixpeak >= 1 ) and ( ixpeak <= 27 ):
+                                if ( ixpeak - xpeak == 0.5 ) and ( iypeak - ypeak == 0.5 ):
+                                    assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak-1, ixpeak], rel=1e-5 )
+                                    assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak, ixpeak-1], rel=1e-5 )
+                                    assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak-1, ixpeak-1], rel=1e-5 )
+                                elif ixpeak - xpeak == 0.5:
+                                    assert clip[iypeak, ixpeak] == pytest.approx( clip[ iypeak, ixpeak-1], rel=1e-5 )
+                                    assert clip[iypeak+1, ixpeak] < clip[iypeak, ixpeak]
+                                    assert clip[iypeak-1, ixpeak] < clip[iypeak, ixpeak]
+                                    assert clip[iypeak+1, ixpeak-1] < clip[iypeak, ixpeak]
+                                    assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
+                                elif iypeak - ypeak == 0.5:
+                                    assert clip[iypeak, ixpeak] == pytest.approx( clip[ iypeak-1, ixpeak], rel=1e-5 )
+                                    assert clip[iypeak, ixpeak+1] < clip[iypeak, ixpeak]
+                                    assert clip[iypeak, ixpeak-1] < clip[iypeak, ixpeak]
+                                    assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
+                                    assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
+                                else:
+                                    assert clip[iypeak, ixpeak] > clip[iypeak-1, ixpeak]
+                                    assert clip[iypeak, ixpeak] > clip[iypeak+1, ixpeak]
+                                    assert clip[iypeak, ixpeak] > clip[iypeak, ixpeak+1]
+                                    assert clip[iypeak, ixpeak] > clip[iypeak, ixpeak-1]
+                            else:
+                                punted += 1
+                        else:
+                            cy, cx = scipy.ndimage.center_of_mass( clip )
+                            if nearishedge:
+                                numnearish += 1
+                                assert clip.sum() == pytest.approx( 0.99, abs=0.01 )
+                                assert cx == pytest.approx( xpeak, abs=0.06 )
+                                assert cy == pytest.approx( ypeak, abs=0.06 )
+                            else:
+                                numnotnear += 1
+                                assert clip.sum() == pytest.approx( 1., abs=0.005 )
+                                assert cx == pytest.approx( xpeak, abs=0.01 )
+                                assert cy == pytest.approx( ypeak, abs=0.01 )
+
+        SNLogger.debug( f"test_get_stamp_centered_oversampled: {numnear} near edge ({punted} punted), {numnearish} "
+                        f"nearish edge, {numnotnear} not near edge" )
+
+
+    # Test the scary case where we pass a PSF that's not centered on its natural clip.
+    # (Why would you DO that?)
+    def run_test_get_stamp_offset_oversampled( self, oversamp=3, sigma=1.2 ):
+        n = 0
+        t = 0
+
+        psfposfracs = [ 0.3792, 0., 0.5, 0.8 ]
+        for xposfrac in psfposfracs:
+            xpos = 1023 + xposfrac
+            for yposfrac in psfposfracs:
+                ypos = 511 + yposfrac
+                psf, datacx, datacy = self.make_psf_for_test_stamp( xpos, ypos, oversamp=oversamp, sigmax=sigma )
+                # Make sure the raw data array we passed is at the right spot
+                xround = np.floor( xpos + 0.5 )
+                yround = np.floor( ypos + 0.5 )
+                cy, cx = scipy.ndimage.center_of_mass( psf.oversampled_data )
+                assert cy == pytest.approx( datacy, abs=0.01*oversamp )
+                assert cx == pytest.approx( datacx, abs=0.01*oversamp )
+
+
+                # If we just get_stamp(), it will get it at the x, y we created with
+                t0 = time.perf_counter()
+                clip = psf.get_stamp()
+                t += time.perf_counter() - t0
+                n += 1
+                assert clip.shape == ( 29, 29 )
+                cy, cx = scipy.ndimage.center_of_mass( clip )
+                assert cx == pytest.approx( 14. + (xpos-xround), abs=0.01 )
+                assert cy == pytest.approx( 14. + (ypos-yround), abs=0.01 )
+
+
+                relpos = [ -2.5, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 2.5 ]
+                ctrexp = [ 13.5,  14.,  14.2, 13.9, 14., 14.1, 13.8, 13.5 ]
+                # OMG, N⁴
+                for xrel, xctr in zip( relpos, ctrexp ):
+                    for yrel, yctr in zip( relpos, ctrexp ):
+                        clip = psf.get_stamp( 1023 + xrel, 511 + yrel )
+                        assert clip.shape == ( 29, 29 )
+                        cy, cx = scipy.ndimage.center_of_mass( clip )
+                        assert cx == pytest.approx( xctr, abs=0.01 )
+                        assert cy == pytest.approx( yctr, abs=0.01 )
+
+        # OMGOMG, N⁶
+        # (Minimize number of cases, and don't bother testing near-the-edge
+        #  stuff that got tested for intrinsically centered psfs.)
+        psfposfracs = [ 0.3792, 0.8 ]
+        for xposfrac in psfposfracs:
+            xpos = 1023 + xposfrac
+            for yposfrac in psfposfracs:
+                ypos = 511 + yposfrac
+                psf, _, _ = self.make_psf_for_test_stamp( xpos, ypos, oversamp=oversamp, sigmax=sigma )
+
+                relpos = [ -2.5, -0.1,  0.2 ]
+                ctrexp = [ 13.5, 13.9, 14.2 ]
+                off = [ -3, 0, None, 2 ]
+                for xrel, xctr in zip( relpos, ctrexp ):
+                    for yrel, yctr in zip( relpos, ctrexp ):
+                        for xoff in off:
+                            x0 = 1023 + xoff if xoff is not None else None
+                            xpeak = 14. + xrel - xoff if xoff is not None else xctr
+                            for yoff in off:
+                                y0 = 511 + yoff if yoff is not None else None
+                                ypeak = 14. + yrel - yoff if yoff is not None else yctr
+
+                                t0 = time.perf_counter()
+                                clip = psf.get_stamp( 1023 + xrel, 511 + yrel, x0=x0, y0=y0 )
+                                t += time.perf_counter() - t0
+                                n += 1
+                                assert clip.shape == ( 29, 29 )
+                                cy, cx = scipy.ndimage.center_of_mass( clip )
+                                assert cx == pytest.approx( xpeak, abs=0.01 )
+                                assert cy == pytest.approx( ypeak, abs=0.01 )
+
+        SNLogger.debug( f"test_get_stamp_offset_oversampled: average get_stamp runtime: {t/n} over {n} runs" )

--- a/snappl/tests/conftest.py
+++ b/snappl/tests/conftest.py
@@ -10,9 +10,11 @@ from snappl.image import FITSImage, OpenUniverse2024FITSImage
 
 from snpit_utils.config import Config
 
+
 @pytest.fixture( scope='session', autouse = True )
 def init_config():
     Config.init( '/snappl/snappl/tests/snappl_test_config.yaml', setdefault = True )
+
 
 @pytest.fixture( scope='module' )
 def ou2024imagepath():

--- a/snappl/tests/docker-compose.yaml
+++ b/snappl/tests/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
   runtests:
     image: rknop/roman-snpit-env:cpu-dev
     working_dir: /snappl
+    environment:
+      GITHUB_SKIP: 1
     entrypoint:
       - /bin/sh
       - -c

--- a/snappl/tests/snappl_test_config.yaml
+++ b/snappl/tests/snappl_test_config.yaml
@@ -1,5 +1,5 @@
-ou2024psf:
-  config_file: /snappl/snappl/tests/tds.yaml
+ou24psf:
+  config_file: /sn_info_dir/tds.yaml
 
 photometry:
     snappl:

--- a/snappl/tests/snappl_test_config.yaml
+++ b/snappl/tests/snappl_test_config.yaml
@@ -1,3 +1,6 @@
+ou2024psf:
+  config_file: /snappl/snappl/tests/tds.yaml
+
 photometry:
     snappl:
         A25ePSF_path: /snappl/snappl/tests/testdata/A25ePSF

--- a/snappl/tests/tds.yaml
+++ b/snappl/tests/tds.yaml
@@ -1,0 +1,161 @@
+# Default settings for roman simulation
+# Includes creation of noisless oversampled images (including PSF)
+#  -- processing of other detector and instrument effects are still handled in the
+#     python postprocessing layer to enable things not currently in galsim.roman
+
+modules:
+
+    # Including galsim.roman in the list of modules to import will add a number of Roman-specific
+    # functions and classes that we will use here.
+    - roman_imsim
+    - galsim.roman
+
+    # We need this for one of our Eval items.  GalSim does not by default import datetime into
+    # the globals dict it uses when evaluating Eval items, so we can tell it to import it here.
+    - datetime
+
+# Define some other information about the images
+image:
+
+    # A special Image type that knows all the Roman SCA geometry, WCS, gain, etc.
+    # It also by default applies a number of detector effects, but these can be turned
+    # off if desired by setting some parameters (given below) to False.
+    type: roman_sca
+
+    wcs:
+        type: RomanWCS
+        SCA: '@image.SCA'
+        ra: { type: ObSeqData, field: ra }
+        dec: { type: ObSeqData, field: dec }
+        pa: { type: ObSeqData, field: pa }
+        mjd: { type: ObSeqData, field: mjd }
+        max_sun_angle: 50
+        force_cvz: True
+
+    bandpass:
+        type: RomanBandpass
+        name: { type: ObSeqData, field: filter }
+
+    # When you want to have multiple images generate the same random galaxies, then
+    # you can set up multiple random number generators with different update cadences
+    # by making random_seed a list.
+    # The default behavior is just to have the random seeds for each object go in order by
+    # object number across all images, but this shows how to set it up so we use two separate
+    # cadences.
+    # The first one behaves normally, which will be used for things like noise on the image.
+    # The second one sets the initial seed for each object to repeat to the same starting value
+    # at the start of each filter.  If we were doing more than 3 total files, it would then
+    # move on to another sequence for the next 3 and so on.
+    random_seed:
+        # Used for noise and nobjects.
+        - { type: ObSeqData, field: visit }
+
+        # Used for objects.  Repeats sequence for each filter
+        # Note: Don't use $ shorthand here, since that will implicitly be evaluated once and then
+        # treated the same way as an integer (i.e. making a regular sequence starting from that
+        # value).  Using an explicit dict with an Eval type means GalSim will leave it alone and
+        # evaluate it as is for each object.
+
+
+    # We're just doing one SCA here.
+    # If you wanted to do all of them in each of three filters (given below), you could use:
+    #
+    # SCA:
+    #     type: Sequence
+    #     first: 1
+    #     last: 18
+    #     repeat: 3  # repeat each SCA num 3 times before moving on, for the 3 filters.
+    #
+    SCA: 10
+    mjd: { type: ObSeqData, field: mjd }
+    filter: { type: ObSeqData, field: filter }
+    exptime: { type: ObSeqData, field: exptime }
+
+    # Photon shooting is way faster for chromatic objects than fft, especially when most of them
+    # are fairly faint.  The cross-over point for achromatic objects is generally of order
+    # flux=1.e6 or so (depending on the profile).  Most of our objects here are much fainter than
+    # that.  The fft rendering for chromatic is a factor of 10 or so slower still, whereas
+    # chromatic photon shooting is only slighly slower than achromatic, so the difference
+    # is even more pronounced in this case.
+    draw_method: 'auto'
+
+    # These are all by default turned on, but you can turn any of them off if desired:
+    ignore_noise: True
+    stray_light: False
+    thermal_background: False
+    reciprocity_failure: False
+    dark_current: False
+    nonlinearity: False
+    ipc: False
+    read_noise: False
+    sky_subtract: False
+
+stamp:
+    type: Roman_stamp
+    world_pos:
+        type: SkyCatWorldPos
+    exptime: { type: ObSeqData, field: exptime }
+
+    photon_ops:
+        -
+            type: ChargeDiff
+
+# psf:
+#     type: roman_psf
+#     # If omitted, it would figure this out automatically, because we are using the RomanSCA image
+#     # type.  But if we weren't, you'd have to tell it which SCA to build the PSF for.
+#     SCA: '@image.SCA'
+#     # n_waves defines how finely to sample the PSF profile over the bandpass.
+#     # Using 10 wavelengths usually gives decent accuracy.
+#     n_waves: 10
+
+# Define the galaxy type and positions to use
+gal:
+    type: SkyCatObj
+
+input:
+    obseq_data:
+        file_name: /sims_dir/RomanTDS/Roman_TDS_obseq_11_6_23.fits
+        visit: 80840
+        SCA: '@image.SCA'
+    roman_psf:
+        SCA: '@image.SCA'
+        n_waves: 5
+    sky_catalog:
+        file_name: /cwork/mat90/RomanDESC_sims_2024/roman_rubin_cats_v1.1.2_faint/skyCatalog.yaml 
+        edge_pix: 512
+        mjd: { type: ObSeqData, field: mjd }
+        exptime: { type: ObSeqData, field: exptime }          
+        obj_types: ['diffsky_galaxy', 'star', 'snana']
+
+output:
+
+    nfiles: 1
+    dir: /global/cfs/cdirs/lsst/shared/external/roman-desc-sims/Roman_data/RomanTDS/RomanTDS/images/truth
+    file_name:
+        type: FormattedStr
+        format: "Roman_TDS_truth_%s_%i_%i.fits.gz"
+        items:
+            - { type: ObSeqData, field: filter }
+            - { type: ObSeqData, field: visit }
+            - '@image.SCA'
+
+    truth:
+        dir: /global/cfs/cdirs/lsst/shared/external/roman-desc-sims/Roman_data/RomanTDS/truth
+        file_name:
+            type: FormattedStr
+            format: "Roman_TDS_index_%s_%i_%i.txt"
+            items:
+                - { type: ObSeqData, field: filter }
+                - { type: ObSeqData, field: visit }
+                - '@image.SCA'
+        columns:
+            object_id: "@object_id"
+            ra: "$sky_pos.ra.deg"
+            dec: "$sky_pos.dec.deg"
+            x: "$image_pos.x"
+            y: "$image_pos.y"
+            realized_flux: "@realized_flux"
+            flux: "@flux"
+            mag: "@mag"
+            obj_type: "@object_type"

--- a/snappl/tests/test_A25ePSF.py
+++ b/snappl/tests/test_A25ePSF.py
@@ -5,11 +5,10 @@ from scipy.stats import moment
 
 # IMPORTS Internal
 from snappl.psf import PSF
-from snpit_utils.config import Config
-from snappl.psf import PSF
+
 
 def test_A25ePSF():
-    
+
     psf = PSF.get_psf_object( 'A25ePSF', band = 'J129', sca = 1, x = 1277.5, y = 1277.5 )
 
     assert psf._data.sum() == pytest.approx( 1.0, rel=1e-9 )
@@ -19,9 +18,9 @@ def test_A25ePSF():
     assert psf._y == np.floor(1277.5)
     assert moment( psf._data, order=2, axis=0 ).sum() == pytest.approx( 0.00013298609785954455, rel=1e-9 )
     assert moment( psf._data, order=2, axis=1 ).sum() == pytest.approx( 0.00013333930898889708, rel=1e-9 )
-    
+
     psf = PSF.get_psf_object( 'A25ePSF', band = 'J129', sca = 1, x = 1060, y = 1500 )
-    
+
     assert psf._data.sum() == pytest.approx( 1.0, rel=1e-9 )
     assert psf._data.mean() == pytest.approx( 0.00016866250632484398, rel=1e-9 )
     assert psf._data.std() == pytest.approx( 0.001380374023163906, rel=1e-9 )
@@ -36,12 +35,10 @@ def test_A25ePSF():
     assert psf._data.sum() == pytest.approx(1.0, rel=1e-9)
     assert moment( psf._data, order=2, axis=0 ).sum() == pytest.approx( 0.0001333651767527484, rel=1e-9 )
     assert moment( psf._data, order=2, axis=1 ).sum() == pytest.approx( 0.00013370914646239755, rel=1e-9 )
-    assert psf._x == np.floor(2810.5) 
+    assert psf._x == np.floor(2810.5)
     assert psf._y == np.floor(1277.5)
 
     for sca in [2, 3]:
         for x in [0, 3500]:
             with pytest.raises( FileNotFoundError, match='No such file or directory' ):
                 psf = PSF.get_psf_object ('A25ePSF', band='J129', sca=sca, x=x, y=1300 )
-
-    

--- a/snappl/tests/test_ou24psf.py
+++ b/snappl/tests/test_ou24psf.py
@@ -18,6 +18,7 @@ from snappl.psf import PSF
 #   podman instance using the interactive_perlmutter.sh script in that
 #   same directory.
 
+
 @pytest.mark.skipif( os.getenv('GITHUB_SKIP'), reason="Skipping test until we have galsim data" )
 def test_slow_normalization():
     # This isn't really testing snappl code, it's checking out galsim.
@@ -35,7 +36,7 @@ def test_slow_normalization():
     #   downsampled.  But, maybe it is.  Go read the code to find out.
     smallstamp = smallpsfobj.get_stamp( seed=42 )
     assert smallstamp.shape == ( 41, 41 )
-    
+
     assert bigstamp.sum() == pytest.approx( 1., abs=0.001 )
 
     x0 = bigsize // 2 - smallsize // 2
@@ -104,16 +105,16 @@ def test_slow_get_stamp():
     cy, cx = scipy.ndimage.center_of_mass( stamp )
     assert cx == pytest.approx( 18.22, abs=0.02 )
     assert cy == pytest.approx( 22.42, abs=0.03 )
-    
-    
-@pytest.mark.skipif( os.getenv('GITHUB_SKIP'), reason="Skipping test until we have galsim data" )
-def test_get_stamp():
-    # Use the defaults, which will be an internal image of size 201 and a stamp size of 41
-    psfobj = PSF.get_psf_object( "ou24PSF", pointing=6, sca=17, oversample_factor=11,  oversampled_size=451 )
-    assert isinstance( psfobj, snappl.psf.ou24PSF )
 
-    # Try a basic centered PSDF
-    stamp = psfobj.get_stamp()
-    assert stamp.shape == ( 41, 41 )
-    import pdb; pdb.set_trace()
-    pass
+
+# Continue this when ou24psf is more than a wrapper around ou24PSF_slow
+# @pytest.mark.skipif( os.getenv('GITHUB_SKIP'), reason="Skipping test until we have galsim data" )
+# def test_get_stamp():
+#     # Use the defaults, which will be an internal image of size 201 and a stamp size of 41
+#     psfobj = PSF.get_psf_object( "ou24PSF", pointing=6, sca=17, oversample_factor=11,  oversampled_size=451 )
+#     assert isinstance( psfobj, snappl.psf.ou24PSF )
+#
+#     # Try a basic centered PSDF
+#     stamp = psfobj.get_stamp()
+#     assert stamp.shape == ( 41, 41 )
+#     # TODO MORE

--- a/snappl/tests/test_ou24psf.py
+++ b/snappl/tests/test_ou24psf.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+
+from astropy.io import fits
+
+from snappl.psf import ou24PSF
+
+# This test won't work on github until we get the right subset of galsim data
+#   properly imported.
+@pytest.mark.skipif( os.getenv('GITHUB_SKIP'), "Skipping test until we have galsim data" )
+def test_get_stamp():
+    psfobj = ou24PSF( pointing=6, sca=17, size=41. )
+
+    stamp = psfobj.get_stamp( 2048, 2048 )
+    fits.io.write_to( 'deleteme.fits', stamp, overwrite=True )
+    
+    

--- a/snappl/tests/test_ou24psf.py
+++ b/snappl/tests/test_ou24psf.py
@@ -1,17 +1,84 @@
 import os
 import pytest
 
-from astropy.io import fits
+import scipy
+
+from astropy.io import fits  # noqa: F401
 
 from snappl.psf import ou24PSF
 
-# This test won't work on github until we get the right subset of galsim data
+# These tests won't work on github until we get the right subset of galsim data
 #   properly imported.
-@pytest.mark.skipif( os.getenv('GITHUB_SKIP'), "Skipping test until we have galsim data" )
+
+# They depend on a tds.yaml file existing in /sn_info_dir, and some of
+#   the directories referred therein to have the right stuff in them.
+#   Look in the phrosty archive under phrosty/examples/perlmutter/tds.yaml for
+#   one such file that will work on perlmutter, *if* you also run in a
+#   podman instance using the interactive_perlmutter.sh script in that
+#   same directory.
+
+
+@pytest.mark.skipif( os.getenv('GITHUB_SKIP'), reason="Skipping test until we have galsim data" )
+def test_normalization():
+    # This isn't really testing snappl code, it's checking out galsim We
+    # use a random seed here for repeatibility.  Empirically, the PSF
+    # normalization in the smaller clip varies by at least several
+    # tenths of a percent when you use different random numbers.
+    bigsize = 201
+    smallsize = 41
+    bigpsfobj = ou24PSF( pointing=6, sca=17, size=bigsize )
+    bigstamp = bigpsfobj.get_stamp( seed=42 )
+    smallpsfobj = ou24PSF( pointing=6, sca=17, size=smallsize )
+    # Using the same seed here probably isn't doing what we want it to do,
+    #   i.e. creating the same realization of the PSF that then gets
+    #   downsampled.  But, maybe it is.  Go read the code to find out.
+    smallstamp = smallpsfobj.get_stamp( seed=42 )
+
+    assert bigstamp.sum() == pytest.approx( 1., abs=0.001 )
+
+    x0 = bigsize // 2 - smallsize // 2
+    x1 = x0 + smallsize
+    assert smallstamp.sum() == pytest.approx( bigstamp[x0:x1,x0:x1].sum(), rel=1e-5 )
+
+
+@pytest.mark.skipif( os.getenv('GITHUB_SKIP'), reason="Skipping test until we have galsim data" )
 def test_get_stamp():
     psfobj = ou24PSF( pointing=6, sca=17, size=41. )
 
-    stamp = psfobj.get_stamp( 2048, 2048 )
-    fits.io.write_to( 'deleteme.fits', stamp, overwrite=True )
-    
-    
+    # It's slow getting galsim PSFs with photon ops, so we're not going to
+    #   do as exhaustive of tets as we do for OversampledImagePSF
+
+    # Try a basic centered PSF
+    stamp = psfobj.get_stamp( seed=42 )
+    assert stamp.shape == ( 41, 41 )
+    # Empirically, a 41×41 stamp comes out at 0.986.  See test_normalization above.
+    assert stamp.sum() == pytest.approx( 0.986, abs=0.001 )
+    cy, cx = scipy.ndimage.center_of_mass( stamp )
+    # The roman PSF is asymmetric, so we don't expect the CoM to be the exact center.
+    # The comparison numbers are what we got the first time we ran this test...
+    assert cx == pytest.approx( 19.716, abs=0.01 )
+    assert cy == pytest.approx( 19.922, abs=0.01 )
+
+    centerstamp = stamp
+
+    # Try an offcenter PSF that's still centered on a pixel
+    # The wings of this PSF are monstrous, so the centroiding
+    #   doesn't come out quite precise when the thing is offset
+    #   this much.
+    stamp = psfobj.get_stamp( 2048., 2048., x0=2050, y0=2040, seed=42 )
+    assert stamp.shape == ( 41, 41 )
+    cy, cx = scipy.ndimage.center_of_mass( stamp )
+    assert cx == pytest.approx( 19.716 + ( 2048 - 2050 ), abs=0.2 )
+    assert cy == pytest.approx( 19.922 + ( 2048 - 2040 ), abs=0.2 )
+    # This stamp should just be a shifted version of centerstamp; verify
+    #   that.  This check should be much more precise than the
+    #   centroids, as wing-cutting won't matter for this check.
+    # (Not *exactly* because centerstamp is at 2044,2044, not 2048,
+    #   2048, but the PSF can't vary much over 4 pixels...)
+    absoff = 0.004 * centerstamp[ 20, 20 ]
+    for xoff in [ -1, 0, 1 ]:
+        for yoff in [ -1, 0, 1 ]:
+            assert ( stamp[ 20 + yoff + 2048-2040, 20 + xoff + 2048-2050 ] ==
+                     pytest.approx( centerstamp[ 20 + yoff, 20 + xoff ], abs=absoff ) )
+
+    # KEEP GOING

--- a/snappl/tests/test_ou24psf.py
+++ b/snappl/tests/test_ou24psf.py
@@ -5,11 +5,12 @@ import scipy
 
 from astropy.io import fits  # noqa: F401
 
-from snappl.psf import ou24PSF
+import snappl.psf
+from snappl.psf import PSF
 
 # These tests won't work on github until we get the right subset of galsim data
 #   properly imported.
-
+#
 # They depend on a tds.yaml file existing in /sn_info_dir, and some of
 #   the directories referred therein to have the right stuff in them.
 #   Look in the phrosty archive under phrosty/examples/perlmutter/tds.yaml for
@@ -17,23 +18,24 @@ from snappl.psf import ou24PSF
 #   podman instance using the interactive_perlmutter.sh script in that
 #   same directory.
 
-
 @pytest.mark.skipif( os.getenv('GITHUB_SKIP'), reason="Skipping test until we have galsim data" )
-def test_normalization():
-    # This isn't really testing snappl code, it's checking out galsim We
-    # use a random seed here for repeatibility.  Empirically, the PSF
-    # normalization in the smaller clip varies by at least several
-    # tenths of a percent when you use different random numbers.
+def test_slow_normalization():
+    # This isn't really testing snappl code, it's checking out galsim.
+    # Empirically, the PSF normalization in the smaller clip varies by
+    # at least several tenths of a percent when you use different random
+    # seeds.
     bigsize = 201
     smallsize = 41
-    bigpsfobj = ou24PSF( pointing=6, sca=17, size=bigsize )
+    bigpsfobj = PSF.get_psf_object( "ou24PSF_slow", pointing=6, sca=17, size=bigsize )
     bigstamp = bigpsfobj.get_stamp( seed=42 )
-    smallpsfobj = ou24PSF( pointing=6, sca=17, size=smallsize )
+    assert bigstamp.shape == ( 201, 201 )
+    smallpsfobj = PSF.get_psf_object( "ou24PSF_slow", pointing=6, sca=17, size=smallsize )
     # Using the same seed here probably isn't doing what we want it to do,
     #   i.e. creating the same realization of the PSF that then gets
     #   downsampled.  But, maybe it is.  Go read the code to find out.
     smallstamp = smallpsfobj.get_stamp( seed=42 )
-
+    assert smallstamp.shape == ( 41, 41 )
+    
     assert bigstamp.sum() == pytest.approx( 1., abs=0.001 )
 
     x0 = bigsize // 2 - smallsize // 2
@@ -42,11 +44,13 @@ def test_normalization():
 
 
 @pytest.mark.skipif( os.getenv('GITHUB_SKIP'), reason="Skipping test until we have galsim data" )
-def test_get_stamp():
-    psfobj = ou24PSF( pointing=6, sca=17, size=41. )
+def test_slow_get_stamp():
+    psfobj = PSF.get_psf_object( "ou24PSF_slow", pointing=6, sca=17, size=41. )
+    assert isinstance( psfobj, snappl.psf.ou24PSF_slow )
 
     # It's slow getting galsim PSFs with photon ops, so we're not going to
-    #   do as exhaustive of tets as we do for OversampledImagePSF
+    #   do as exhaustive of tets as we do for OversampledImagePSF.  Use
+    #   an explicit seed here so tests are reproducible.
 
     # Try a basic centered PSF
     stamp = psfobj.get_stamp( seed=42 )
@@ -81,4 +85,35 @@ def test_get_stamp():
             assert ( stamp[ 20 + yoff + 2048-2040, 20 + xoff + 2048-2050 ] ==
                      pytest.approx( centerstamp[ 20 + yoff, 20 + xoff ], abs=absoff ) )
 
-    # KEEP GOING
+    # Try a PSF centered between two pixels.  Because of how we
+    #   define 0.5 behavior in PSF.get_stamp, this should be
+    #   centered to the *left* of the center of the image.
+    stamp = psfobj.get_stamp( 2048.5, 2048., seed=42 )
+    assert stamp.shape == ( 41, 41 )
+    assert stamp.sum() == pytest.approx( 0.986, abs=0.001 )
+    cy, cx = scipy.ndimage.center_of_mass( stamp )
+    assert cx == pytest.approx( 19.22, abs=0.02 )
+    assert cy == pytest.approx( 19.92, abs=0.02 )
+
+    # Try an offcenter PSF that's centered on a corner
+    # The PSF center should be at -1.5, +2.5 pixels
+    # relative to the stamp center... but then
+    # offset because of the asymmetry of the roman PSF.
+    stamp = psfobj.get_stamp( 2048.5, 2048.5, x0=2050, y0=2046, seed=42 )
+    assert stamp.shape == ( 41, 41 )
+    cy, cx = scipy.ndimage.center_of_mass( stamp )
+    assert cx == pytest.approx( 18.22, abs=0.02 )
+    assert cy == pytest.approx( 22.42, abs=0.03 )
+    
+    
+@pytest.mark.skipif( os.getenv('GITHUB_SKIP'), reason="Skipping test until we have galsim data" )
+def test_get_stamp():
+    # Use the defaults, which will be an internal image of size 201 and a stamp size of 41
+    psfobj = PSF.get_psf_object( "ou24PSF", pointing=6, sca=17, oversample_factor=11,  oversampled_size=451 )
+    assert isinstance( psfobj, snappl.psf.ou24PSF )
+
+    # Try a basic centered PSDF
+    stamp = psfobj.get_stamp()
+    assert stamp.shape == ( 41, 41 )
+    import pdb; pdb.set_trace()
+    pass

--- a/snappl/tests/test_oversampled_image_psf.py
+++ b/snappl/tests/test_oversampled_image_psf.py
@@ -1,3 +1,4 @@
+
 import pytest
 import time
 
@@ -39,7 +40,7 @@ def test_interactive_write_stamp_to_fits_for_visual_inspection( testpsf ):
     fits.writeto( 'test_deleteme_resamp.fits', testpsf.get_stamp(), overwrite=True )
 
 
-def make_psf_for_test_stamp( x=1023, y=1023, oversamp=3 ):
+def make_psf_for_test_stamp( x=1023, y=511, oversamp=3 ):
     # Make a 3x oversampled PSF that's a gaussian with sigma 1.2 (in
     # image pixel units, not oversampled units).  2√(2ln2)*1.2 = FWHM of
     # 2.83, so for a radius of 5 FWHMs (to be really anal), we want a
@@ -81,6 +82,7 @@ def test_get_stamp_centered_oversampled():
     expectedgauss /= expectedgauss.sum()
     clip = psf.get_stamp()
     assert clip.shape == ( 29, 29 )
+    assert clip.sum() == pytest.approx( 1, abs=0.005 )
     # Doing an absolute, not a relative, comparison because where the gaussian is
     #   approximately zero, we don't need it to be identically 0
     assert np.all( clip == pytest.approx( expectedgauss, abs=0.001 / ( 29*29 ) ) )
@@ -89,30 +91,188 @@ def test_get_stamp_centered_oversampled():
     # expected
 
     # When the relative position is offset by an integer from the place
-    #   we evaluted the pixel at ((1023, 1023) in this case), the PSF
+    #   we evaluted the pixel at ((1023, 511) in this case), the PSF
     #   should still be centered on the center pixel of the image.
+    # NOTICE : when the fractional part is exactly 0.5, the PSF is
+    #   centered down and to the left of the center pixel of the clip.
+    #   This is as documented in snappl.psf.PSF.get_stamp
     relpos = [ -2.5, -1.8, -1.4, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 1.0, 1.4,   1.8,  2.5 ]
     ctrexp = [ 13.5, 14.2, 13.6,   14., 14.2, 13.9, 14., 14.1, 13.8, 14., 14.4, 13.8, 13.5 ]
 
     for xrel, xctr in zip( relpos, ctrexp ):
         for yrel, yctr in zip( relpos, ctrexp ):
-            clip = psf.get_stamp( 1023 + xrel, 1023 + yrel )
+            clip = psf.get_stamp( 1023 + xrel, 511 + yrel )
+            assert clip.sum() == pytest.approx( 1, abs=0.005 )
             assert clip.shape == ( 29, 29 )
             cy, cx = scipy.ndimage.center_of_mass( clip )
             assert cx == pytest.approx( xctr, abs=0.01 )
             assert cy == pytest.approx( yctr, abs=0.01 )
 
+    # Now try the case where we pass x0 and y0 to get_stamp.
 
-# Test the scary case where we pass a PSF that's not centered on its natural clip
+    # A handful of specific cases with non-None x0 and y0 to help the
+    #   writer of this test think about all the upcoming for loops.
+
+    # First case: we have a PSF that we want centered three pixels up
+    #   and to the right.  We'll pass x0 and y0 as (1023, 511) (which is
+    #   the default), and then give x and y as 1026 and 514.  This is *different*
+    #   from x=1026, y=514, x0=None, y=None; in that case the PSF would be
+    #   centered, because it would determine a different x0 and y0 from what
+    #   we pass in this example.
+
+    clip = psf.get_stamp( 1026., 514., x0=1023, y0=511 )
+    assert clip.sum() == pytest.approx( 1., abs=0.005 )
+    assert clip.shape == ( 29, 29 )
+    cy, cx = scipy.ndimage.center_of_mass( clip )
+    assert cx == pytest.approx( 14.+3., abs=0.01 )
+    assert cy == pytest.approx( 14.+3., abs=0.01 )
+    # Uncomment for visual debugging
+    # fits.writeto( "test_get_stamp_centered_oversampled_1.fits", clip, overwrite=True )
+
+    # Second case: we're going to put the psf at its standard position
+    # of 1023, 511, but then we want the center of the clip to
+    # correspond to 1022, 512 on the image.  So, the PSF should be one
+    # pixel to the right and one pixel down.
+
+    clip = psf.get_stamp( 1023., 511., x0=1022, y0=512 )
+    assert clip.sum() == pytest.approx( 1., abs=0.005 )
+    assert clip.shape == ( 29, 29 )
+    cy, cx = scipy.ndimage.center_of_mass( clip )
+    assert cx == pytest.approx( 14.+1., abs=0.01 )
+    assert cy == pytest.approx( 14.-1., abs=0.01 )
+    # Uncomment for visual debugging
+    # fits.writeto( "test_get_stamp_centered_oversampled_2.fits", clip, overwrite=True )
+
+    # Third case: if we just ask for (x=1023.5, y=511.5), we'll get a
+    # PSF centered down and to the left of the center of the clip,
+    # because of the whole floor thing.  However, if we also give
+    # x0=1023, y0=511, then we should get a PSF centered up and to the
+    # right.
+
+    clip = psf.get_stamp( 1023.5, 511.5 )
+    assert clip.sum() == pytest.approx( 1., abs=0.005 )
+    assert clip.shape == ( 29, 29 )
+    cy, cx = scipy.ndimage.center_of_mass( clip )
+    assert cx == pytest.approx( 14.-0.5, abs=0.01 )
+    assert cy == pytest.approx( 14.-0.5, abs=0.01 )
+    # Uncomment for visual debugging
+    # fits.writeto( "test_get_stamp_centered_oversampled_3.fits", clip, overwrite=True )
+    clip = psf.get_stamp( 1023.5, 511.5, x0=1023, y0=511 )
+    assert clip.sum() == pytest.approx( 1., abs=0.005 )
+    assert clip.shape == ( 29, 29 )
+    cy, cx = scipy.ndimage.center_of_mass( clip )
+    assert cx == pytest.approx( 14.+0.5, abs=0.01 )
+    assert cy == pytest.approx( 14.+0.5, abs=0.01 )
+    # Uncomment for visual debugging
+    # fits.writeto( "test_get_stamp_centered_oversampled_4.fits", clip, overwrite=True )
+
+    # Test a whole bunch in a four-loop.  When off is None then we
+    #   expect the PSF to be centered on the clip at xctr, yctr (pulled
+    #   from the ctrpos array), just as in tests above where we didn't
+    #   pass x0 and y0.  Otherwise, it depends on both x and x0 (or y
+    #   and y0 as appropriate).
+    relpos = [ -2.5, -0.8,  0.,  0.1,  1.4,  1.5 ]
+    ctrpos = [ 13.5, 14.2, 14., 14.1, 14.4, 13.5 ]
+    off = [ -15, -1, 0, None, 3, 12 ]
+    numnear = 0
+    numnearish = 0
+    numnotnear = 0
+    punted = 0
+    for xrel, xctr in zip( relpos, ctrpos ):
+        for yrel, yctr in zip( relpos, ctrpos ):
+            for xoff in off:
+                x0 = 1023 + xoff if xoff is not None else None
+                xpeak = 14. + xrel - xoff if xoff is not None else xctr
+                for yoff in off:
+                    y0 = 511 + yoff if yoff is not None else None
+                    ypeak = 14. + yrel - yoff if yoff is not None else yctr
+
+                    clip = psf.get_stamp( 1023+xrel, 511+yrel, x0=x0, y0=y0 )
+                    assert clip.shape == ( 29, 29 )
+                    # ****
+                    # For visual debugging.  Warning: writes a metric butt-ton of images.
+                    # fits.writeto( f'deteleme_{xrel}_{yrel}_{xoff}_{yoff}.fits', clip, overwrite=True )
+                    # ****
+
+                    # If xpeak or ypeak is too close to the edge, then we don't
+                    #   expect the sum to be 1, because flux will have slopped
+                    #   off of the edge of the clip.  Also, finding the
+                    #   center is fraught; scipy.ndiamge.center_of_mass won't
+                    #   give us the center, because all the missing flux is
+                    #   going to make the formal centroid offset towards
+                    #   the center from the peak.  In that case, satisfy
+                    #   ourself with making sure that the nominal peak
+                    #   pixel is brighter than its neighbors.  (Well...
+                    #   except when the fractional part relpos is 0.5, and
+                    #   then we look at the two (or four) brightest pixels.)
+                    nearishedge = ( xpeak < 3. ) or ( xpeak > 25. ) or ( ypeak < 3. ) or ( ypeak > 25. )
+                    nearedge = ( ( ( xpeak < 2. ) or ( xpeak > 26. ) or ( ypeak < 2. ) or ( ypeak > 26. ) )
+                                 or
+                                 ( ( ( xpeak < 3. ) or ( xpeak > 25. ) )
+                                   and
+                                   ( ( ypeak < 3. ) or ( ypeak > 25. ) )
+                                  )
+                                )
+                    if nearedge:
+                        numnear += 1
+                        assert clip.sum() < 0.98
+                        ixpeak = int( np.floor( xpeak + 0.5 ) )
+                        iypeak = int( np.floor( ypeak + 0.5 ) )
+                        # We're just gonna punt if the peak is off of the edge of the image
+                        if ( iypeak >= 1 ) and ( iypeak <= 27 ) and ( ixpeak >= 1 ) and ( ixpeak <= 27 ):
+                            if ( ixpeak - xpeak == 0.5 ) and ( iypeak - ypeak == 0.5 ):
+                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak-1, ixpeak], rel=1e-5 )
+                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak, ixpeak-1], rel=1e-5 )
+                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak-1, ixpeak-1], rel=1e-5 )
+                            elif ixpeak - xpeak == 0.5:
+                                assert clip[iypeak, ixpeak] == pytest.approx( clip[ iypeak, ixpeak-1], rel=1e-5 )
+                                assert clip[iypeak+1, ixpeak] < clip[iypeak, ixpeak]
+                                assert clip[iypeak-1, ixpeak] < clip[iypeak, ixpeak]
+                                assert clip[iypeak+1, ixpeak-1] < clip[iypeak, ixpeak]
+                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
+                            elif iypeak - ypeak == 0.5:
+                                assert clip[iypeak, ixpeak] == pytest.approx( clip[ iypeak-1, ixpeak], rel=1e-5 )
+                                assert clip[iypeak, ixpeak+1] < clip[iypeak, ixpeak]
+                                assert clip[iypeak, ixpeak-1] < clip[iypeak, ixpeak]
+                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
+                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
+                            else:
+                                assert clip[iypeak, ixpeak] > clip[iypeak-1, ixpeak]
+                                assert clip[iypeak, ixpeak] > clip[iypeak+1, ixpeak]
+                                assert clip[iypeak, ixpeak] > clip[iypeak, ixpeak+1]
+                                assert clip[iypeak, ixpeak] > clip[iypeak, ixpeak-1]
+                        else:
+                            punted += 1
+                    else:
+                        cy, cx = scipy.ndimage.center_of_mass( clip )
+                        if nearishedge:
+                            numnearish += 1
+                            assert clip.sum() == pytest.approx( 0.99, abs=0.01 )
+                            assert cx == pytest.approx( xpeak, abs=0.06 )
+                            assert cy == pytest.approx( ypeak, abs=0.06 )
+                        else:
+                            numnotnear += 1
+                            assert clip.sum() == pytest.approx( 1., abs=0.005 )
+                            assert cx == pytest.approx( xpeak, abs=0.01 )
+                            assert cy == pytest.approx( ypeak, abs=0.01 )
+
+    SNLogger.debug( f"test_get_stamp_centered_oversampled: {numnear} near edge ({punted} punted), {numnearish} "
+                    f"nearish edge, {numnotnear} not near edge" )
+
+
+# Test the scary case where we pass a PSF that's not centered on its natural clip.
+# (Why would you DO that?)
 def test_get_stamp_offset_oversampled():
 
     n = 0
     t = 0
 
     oversamp = 3
-    psfposes = [ 1023.3792, 1023., 1023.5, 1023.8 ]
-    for xpos in psfposes:
-        for ypos in psfposes:
+    psfposfracs = [ 0.3792, 0., 0.5, 0.8 ]
+    for xposfrac in psfposfracs:
+        xpos = 1023 + xposfrac
+        for yposfrac in psfposfracs:
+            ypos = 511 + yposfrac
             psf = make_psf_for_test_stamp( xpos, ypos, oversamp=oversamp )
             # Make sure the raw data array we passed is at the right spot
             xround = np.floor( xpos + 0.5 )
@@ -138,7 +298,7 @@ def test_get_stamp_offset_oversampled():
             # OMG, N⁴
             for xrel, xctr in zip( relpos, ctrexp ):
                 for yrel, yctr in zip( relpos, ctrexp ):
-                    clip = psf.get_stamp( 1023 + xrel, 1023 + yrel )
+                    clip = psf.get_stamp( 1023 + xrel, 511 + yrel )
                     assert clip.shape == ( 29, 29 )
                     cy, cx = scipy.ndimage.center_of_mass( clip )
                     assert cx == pytest.approx( xctr, abs=0.01 )

--- a/snappl/tests/test_oversampled_image_psf.py
+++ b/snappl/tests/test_oversampled_image_psf.py
@@ -1,343 +1,67 @@
-
 import pytest
-import time
-
 import numpy as np
-import scipy
-from astropy.io import fits
+
+import sys
+sys.path.insert( 0, '.' )
+from base_testimagepsf import BaseTestImagePSF
 
 from snappl.psf import PSF, OversampledImagePSF
-from snpit_utils.logger import SNLogger
 
 
-@pytest.fixture
-def testpsf():
-    loaded = np.load('psf_test_data/testpsfarray.npz')
-    arr = loaded['args']
-    mypsf = PSF.get_psf_object( "OversampledImagePSF", data=arr, x=3832., y=255., oversample_factor=3., normalize=True )
-    return mypsf
+class TestOversampledImagePSF( BaseTestImagePSF ):
+    __psfclass__ = OversampledImagePSF
+
+    @pytest.fixture
+    def testpsf( self ):
+        loaded = np.load('psf_test_data/testpsfarray.npz')
+        arr = loaded['args']
+        mypsf = PSF.get_psf_object( "OversampledImagePSF", data=arr, x=3832., y=255.,
+                                    oversample_factor=3., normalize=True )
+        assert isinstance( mypsf, self.__psfclass__ )
+        return mypsf
+
+    def make_psf_for_test_stamp( self, x=1023, y=511, oversamp=3, sigmax=1.2, sigmay=None ):
+        # Make a 3x oversampled PSF that's a gaussian with sigma 1.2 (in
+        # image pixel units, not oversampled units).  2√(2ln2)*1.2 = FWHM of
+        # 2.83, so for a radius of 5 FWHMs (to be really anal), we want a
+        # 29×29 stamp in image units.
+        #
+        # 3× oversampled means an 87×87 data array.  87 // 2 = 43
+        # 5× oversampled means a 145×145 data array.  145 // 2 = 72
+        xc = np.floor( x + 0.5 )
+        yc = np.floor( y + 0.5 )
+
+        sigmay = sigmax if sigmay is None else sigmay
+
+        assert isinstance( oversamp, int )
+        size = int( np.ceil( oversamp * 29 ) )
+        size += 1 if size % 2 == 0 else 0
+        ctr = size // 2
+
+        xvals = np.arange( -ctr, ctr+1 ) + oversamp * ( np.floor( x + 0.5 ) - x )
+        yvals = np.arange( -ctr, ctr+1 ) + oversamp * ( np.floor( y + 0.5 ) - y )
+        ovsigmax = oversamp * sigmax
+        ovsigmay = oversamp * sigmay
+        data = np.exp( -( xvals[np.newaxis,:]**2 / ( 2. * ovsigmax**2 ) +
+                          yvals[:,np.newaxis]**2 / ( 2. * ovsigmay**2 ) ) )
+        data /= data.sum()
+        psf = PSF.get_psf_object( "OversampledImagePSF", data=data, x=x, y=y, oversample_factor=oversamp )
+
+        datacx = size // 2 + ( x - xc ) * oversamp
+        datacy = size // 2 + ( y - yc ) * oversamp
+
+        return psf, datacx, datacy
 
 
-def test_create( testpsf ):
-    assert isinstance( testpsf, OversampledImagePSF )
-    assert testpsf._data.sum() == pytest.approx( 1., rel=1e-9 )
-    # data array was 77×77, we are oversampled by 3x, so nominally
-    #  it's 25.7×25.7 on the image.  But, the array size is an integer,
-    #  and it floors, so we should get 25
-    assert testpsf.stamp_size == 25
-    assert testpsf.clip_size == 25
-    assert testpsf.oversample_factor == 3
-    assert testpsf.x == 3832.
-    assert testpsf.y == 255.
-    loaded = np.load( 'psf_test_data/testpsfarray.npz' )
-    arr = loaded['args']
-    assert np.all( arr / arr.sum() == testpsf.oversampled_data )
-    # TODO : test that normalize=False works
+    def test_get_stamp_orientation( self ):
+        self.run_test_get_stamp_orientation()
 
+    def test_get_stamp_centered_oversampled( self ):
+        self.run_test_get_stamp_centered_oversampled()
 
-@pytest.mark.skip( reason="Comment out the skip to write some files for visual inspection" )
-def test_interactive_write_stamp_to_fits_for_visual_inspection( testpsf ):
-    fits.writeto( 'test_deleteme_orig.fits', testpsf._data, overwrite=True )
-    fits.writeto( 'test_deleteme_resamp.fits', testpsf.get_stamp(), overwrite=True )
+    @pytest.mark.xfail( reason="We know this doesn't work right yet." )
+    def test_get_stamp_centered_oversampled_with_undersampled_psf( self ):
+        self.run_test_get_stamp_centered_oversampled( oversamp=3, sigma=0.3 )
 
-
-def make_psf_for_test_stamp( x=1023, y=511, oversamp=3, sigma=1.2 ):
-    # Make a 3x oversampled PSF that's a gaussian with sigma 1.2 (in
-    # image pixel units, not oversampled units).  2√(2ln2)*1.2 = FWHM of
-    # 2.83, so for a radius of 5 FWHMs (to be really anal), we want a
-    # 29×29 stamp in image units.
-    #
-    # 3× oversampled means an 87×87 data array.  87 // 2 = 43
-    # 5× oversampled means a 145×145 data array.  145 // 2 = 72
-
-    assert isinstance( oversamp, int )
-    size = int( np.ceil( oversamp * 29 ) )
-    size += 1 if size % 2 == 0 else 0
-    ctr = size // 2
-
-    xvals = np.arange( -ctr, ctr+1 ) + oversamp * ( np.floor( x + 0.5 ) - x )
-    yvals = np.arange( -ctr, ctr+1 ) + oversamp * ( np.floor( y + 0.5 ) - y )
-    ovsigma = oversamp * sigma
-    data = np.exp( -( xvals[np.newaxis,:]**2 + yvals[:,np.newaxis]**2 ) / ( 2. * ovsigma**2 ) )
-    data /= data.sum()
-    psf = PSF.get_psf_object( "OversampledImagePSF", data=data, x=x, y=y, oversample_factor=oversamp )
-
-    return psf
-
-
-# "centered" here means the original PSF is centered; we're going to
-#   render it offset
-def test_get_stamp_centered_oversampled():
-    oversamp = 3
-    sigma = 1.2
-    psf = make_psf_for_test_stamp( oversamp=oversamp, sigma=sigma )
-
-    # If we just get_stamp(), we should get a 29×29 image centered on the middle
-    # We don't actually really expect the stamp to be exactly expectedgauss, because
-    #   the interpolation in get_stamp() is more sophisticated than just "evaluate
-    #   the gaussian at the point".  We should be oversampled enough, though, that
-    #   it's damn close.
-    clipx = np.arange( -14, 15 )
-    clipy = np.arange( -14, 15 )
-    expectedgauss = np.exp( -( clipx[np.newaxis,:]**2 + clipy[:,np.newaxis]**2 ) / ( 2. * sigma**2 ) )
-    expectedgauss /= expectedgauss.sum()
-    clip = psf.get_stamp()
-    assert clip.shape == ( 29, 29 )
-    assert clip.sum() == pytest.approx( 1, abs=0.005 )
-    # Doing an absolute, not a relative, comparison because where the gaussian is
-    #   approximately zero, we don't need it to be identically 0
-    assert np.all( clip == pytest.approx( expectedgauss, abs=0.001 / ( 29*29 ) ) )
-
-    # Render a bunch that are offset and make sure they center up where
-    # expected
-
-    # When the relative position is offset by an integer from the place
-    #   we evaluted the pixel at ((1023, 511) in this case), the PSF
-    #   should still be centered on the center pixel of the image.
-    # NOTICE : when the fractional part is exactly 0.5, the PSF is
-    #   centered down and to the left of the center pixel of the clip.
-    #   This is as documented in snappl.psf.PSF.get_stamp
-    relpos = [ -2.5, -1.8, -1.4, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 1.0, 1.4,   1.8,  2.5 ]
-    ctrexp = [ 13.5, 14.2, 13.6,   14., 14.2, 13.9, 14., 14.1, 13.8, 14., 14.4, 13.8, 13.5 ]
-
-    for xrel, xctr in zip( relpos, ctrexp ):
-        for yrel, yctr in zip( relpos, ctrexp ):
-            clip = psf.get_stamp( 1023 + xrel, 511 + yrel )
-            assert clip.sum() == pytest.approx( 1, abs=0.005 )
-            assert clip.shape == ( 29, 29 )
-            cy, cx = scipy.ndimage.center_of_mass( clip )
-            assert cx == pytest.approx( xctr, abs=0.01 )
-            assert cy == pytest.approx( yctr, abs=0.01 )
-
-    # Now try the case where we pass x0 and y0 to get_stamp.
-
-    # A handful of specific cases with non-None x0 and y0 to help the
-    #   writer of this test think about all the upcoming for loops.
-
-    # First case: we have a PSF that we want centered three pixels up
-    #   and to the right.  We'll pass x0 and y0 as (1023, 511) (which is
-    #   the default), and then give x and y as 1026 and 514.  This is *different*
-    #   from x=1026, y=514, x0=None, y=None; in that case the PSF would be
-    #   centered, because it would determine a different x0 and y0 from what
-    #   we pass in this example.
-
-    clip = psf.get_stamp( 1026., 514., x0=1023, y0=511 )
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    assert clip.shape == ( 29, 29 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cx == pytest.approx( 14.+3., abs=0.01 )
-    assert cy == pytest.approx( 14.+3., abs=0.01 )
-    # Uncomment for visual debugging
-    # fits.writeto( "test_get_stamp_centered_oversampled_1.fits", clip, overwrite=True )
-
-    # Second case: we're going to put the psf at its standard position
-    # of 1023, 511, but then we want the center of the clip to
-    # correspond to 1022, 512 on the image.  So, the PSF should be one
-    # pixel to the right and one pixel down.
-
-    clip = psf.get_stamp( 1023., 511., x0=1022, y0=512 )
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    assert clip.shape == ( 29, 29 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cx == pytest.approx( 14.+1., abs=0.01 )
-    assert cy == pytest.approx( 14.-1., abs=0.01 )
-    # Uncomment for visual debugging
-    # fits.writeto( "test_get_stamp_centered_oversampled_2.fits", clip, overwrite=True )
-
-    # Third case: if we just ask for (x=1023.5, y=511.5), we'll get a
-    # PSF centered down and to the left of the center of the clip,
-    # because of the whole floor thing.  However, if we also give
-    # x0=1023, y0=511, then we should get a PSF centered up and to the
-    # right.
-
-    clip = psf.get_stamp( 1023.5, 511.5 )
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    assert clip.shape == ( 29, 29 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cx == pytest.approx( 14.-0.5, abs=0.01 )
-    assert cy == pytest.approx( 14.-0.5, abs=0.01 )
-    # Uncomment for visual debugging
-    # fits.writeto( "test_get_stamp_centered_oversampled_3.fits", clip, overwrite=True )
-    clip = psf.get_stamp( 1023.5, 511.5, x0=1023, y0=511 )
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    assert clip.shape == ( 29, 29 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cx == pytest.approx( 14.+0.5, abs=0.01 )
-    assert cy == pytest.approx( 14.+0.5, abs=0.01 )
-    # Uncomment for visual debugging
-    # fits.writeto( "test_get_stamp_centered_oversampled_4.fits", clip, overwrite=True )
-
-    import pdb; pdb.set_trace()
-    pass
-    
-    # Test a whole bunch in a four-loop.  When off is None then we
-    #   expect the PSF to be centered on the clip at xctr, yctr (pulled
-    #   from the ctrpos array), just as in tests above where we didn't
-    #   pass x0 and y0.  Otherwise, it depends on both x and x0 (or y
-    #   and y0 as appropriate).
-    relpos = [ -2.5, -0.8,  0.,  0.1,  1.4,  1.5 ]
-    ctrpos = [ 13.5, 14.2, 14., 14.1, 14.4, 13.5 ]
-    off = [ -15, -1, 0, None, 3, 12 ]
-    numnear = 0
-    numnearish = 0
-    numnotnear = 0
-    punted = 0
-    for xrel, xctr in zip( relpos, ctrpos ):
-        for yrel, yctr in zip( relpos, ctrpos ):
-            for xoff in off:
-                x0 = 1023 + xoff if xoff is not None else None
-                xpeak = 14. + xrel - xoff if xoff is not None else xctr
-                for yoff in off:
-                    y0 = 511 + yoff if yoff is not None else None
-                    ypeak = 14. + yrel - yoff if yoff is not None else yctr
-
-                    clip = psf.get_stamp( 1023+xrel, 511+yrel, x0=x0, y0=y0 )
-                    assert clip.shape == ( 29, 29 )
-                    # ****
-                    # For visual debugging.  Warning: writes a metric butt-ton of images.
-                    # fits.writeto( f'deteleme_{xrel}_{yrel}_{xoff}_{yoff}.fits', clip, overwrite=True )
-                    # ****
-
-                    # If xpeak or ypeak is too close to the edge, then we don't
-                    #   expect the sum to be 1, because flux will have slopped
-                    #   off of the edge of the clip.  Also, finding the
-                    #   center is fraught; scipy.ndiamge.center_of_mass won't
-                    #   give us the center, because all the missing flux is
-                    #   going to make the formal centroid offset towards
-                    #   the center from the peak.  In that case, satisfy
-                    #   ourself with making sure that the nominal peak
-                    #   pixel is brighter than its neighbors.  (Well...
-                    #   except when the fractional part relpos is 0.5, and
-                    #   then we look at the two (or four) brightest pixels.)
-                    nearishedge = ( xpeak < 3. ) or ( xpeak > 25. ) or ( ypeak < 3. ) or ( ypeak > 25. )
-                    nearedge = ( ( ( xpeak < 2. ) or ( xpeak > 26. ) or ( ypeak < 2. ) or ( ypeak > 26. ) )
-                                 or
-                                 ( ( ( xpeak < 3. ) or ( xpeak > 25. ) )
-                                   and
-                                   ( ( ypeak < 3. ) or ( ypeak > 25. ) )
-                                  )
-                                )
-                    if nearedge:
-                        numnear += 1
-                        assert clip.sum() < 0.98
-                        ixpeak = int( np.floor( xpeak + 0.5 ) )
-                        iypeak = int( np.floor( ypeak + 0.5 ) )
-                        # We're just gonna punt if the peak is off of the edge of the image
-                        if ( iypeak >= 1 ) and ( iypeak <= 27 ) and ( ixpeak >= 1 ) and ( ixpeak <= 27 ):
-                            if ( ixpeak - xpeak == 0.5 ) and ( iypeak - ypeak == 0.5 ):
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak-1, ixpeak], rel=1e-5 )
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak, ixpeak-1], rel=1e-5 )
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak-1, ixpeak-1], rel=1e-5 )
-                            elif ixpeak - xpeak == 0.5:
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[ iypeak, ixpeak-1], rel=1e-5 )
-                                assert clip[iypeak+1, ixpeak] < clip[iypeak, ixpeak]
-                                assert clip[iypeak-1, ixpeak] < clip[iypeak, ixpeak]
-                                assert clip[iypeak+1, ixpeak-1] < clip[iypeak, ixpeak]
-                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
-                            elif iypeak - ypeak == 0.5:
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[ iypeak-1, ixpeak], rel=1e-5 )
-                                assert clip[iypeak, ixpeak+1] < clip[iypeak, ixpeak]
-                                assert clip[iypeak, ixpeak-1] < clip[iypeak, ixpeak]
-                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
-                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
-                            else:
-                                assert clip[iypeak, ixpeak] > clip[iypeak-1, ixpeak]
-                                assert clip[iypeak, ixpeak] > clip[iypeak+1, ixpeak]
-                                assert clip[iypeak, ixpeak] > clip[iypeak, ixpeak+1]
-                                assert clip[iypeak, ixpeak] > clip[iypeak, ixpeak-1]
-                        else:
-                            punted += 1
-                    else:
-                        cy, cx = scipy.ndimage.center_of_mass( clip )
-                        if nearishedge:
-                            numnearish += 1
-                            assert clip.sum() == pytest.approx( 0.99, abs=0.01 )
-                            assert cx == pytest.approx( xpeak, abs=0.06 )
-                            assert cy == pytest.approx( ypeak, abs=0.06 )
-                        else:
-                            numnotnear += 1
-                            assert clip.sum() == pytest.approx( 1., abs=0.005 )
-                            assert cx == pytest.approx( xpeak, abs=0.01 )
-                            assert cy == pytest.approx( ypeak, abs=0.01 )
-
-    SNLogger.debug( f"test_get_stamp_centered_oversampled: {numnear} near edge ({punted} punted), {numnearish} "
-                    f"nearish edge, {numnotnear} not near edge" )
-
-
-# Test the scary case where we pass a PSF that's not centered on its natural clip.
-# (Why would you DO that?)
-def test_get_stamp_offset_oversampled():
-
-    oversamp = 3
-    sigma = 1.2
-    n = 0
-    t = 0
-
-    psfposfracs = [ 0.3792, 0., 0.5, 0.8 ]
-    for xposfrac in psfposfracs:
-        xpos = 1023 + xposfrac
-        for yposfrac in psfposfracs:
-            ypos = 511 + yposfrac
-            psf = make_psf_for_test_stamp( xpos, ypos, oversamp=oversamp, sigma=sigma )
-            # Make sure the raw data array we passed is at the right spot
-            xround = np.floor( xpos + 0.5 )
-            yround = np.floor( ypos + 0.5 )
-            cy, cx = scipy.ndimage.center_of_mass( psf.oversampled_data )
-            assert cy == pytest.approx( ( 29 * oversamp ) // 2 + (ypos-yround) * oversamp, abs=0.01*oversamp )
-            assert cx == pytest.approx( ( 29 * oversamp ) // 2 + (xpos-xround) * oversamp, abs=0.01*oversamp )
-
-
-            # If we just get_stamp(), it will get it at the x, y we created with
-            t0 = time.perf_counter()
-            clip = psf.get_stamp()
-            t += time.perf_counter() - t0
-            n += 1
-            assert clip.shape == ( 29, 29 )
-            cy, cx = scipy.ndimage.center_of_mass( clip )
-            assert cx == pytest.approx( 14. + (xpos-xround), abs=0.01 )
-            assert cy == pytest.approx( 14. + (ypos-yround), abs=0.01 )
-
-
-            relpos = [ -2.5, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 2.5 ]
-            ctrexp = [ 13.5,  14.,  14.2, 13.9, 14., 14.1, 13.8, 13.5 ]
-            # OMG, N⁴
-            for xrel, xctr in zip( relpos, ctrexp ):
-                for yrel, yctr in zip( relpos, ctrexp ):
-                    clip = psf.get_stamp( 1023 + xrel, 511 + yrel )
-                    assert clip.shape == ( 29, 29 )
-                    cy, cx = scipy.ndimage.center_of_mass( clip )
-                    assert cx == pytest.approx( xctr, abs=0.01 )
-                    assert cy == pytest.approx( yctr, abs=0.01 )
-
-    # OMGOMG, N⁶
-    # (Minimize number of cases, and don't bother testing near-the-edge
-    #  stuff that got tested for intrinsically centered psfs.)
-    psfposfracs = [ 0.3792, 0.8 ]
-    for xposfrac in psfposfracs:
-        xpos = 1023 + xposfrac
-        for yposfrac in psfposfracs:
-            ypos = 511 + yposfrac
-            psf = make_psf_for_test_stamp( xpos, ypos, oversamp=oversamp, sigma=sigma )
-
-            relpos = [ -2.5, -0.1,  0.2 ]
-            ctrexp = [ 13.5, 13.9, 14.2 ]
-            off = [ -3, 0, None, 2 ]
-            for xrel, xctr in zip( relpos, ctrexp ):
-                for yrel, yctr in zip( relpos, ctrexp ):
-                    for xoff in off:
-                        x0 = 1023 + xoff if xoff is not None else None
-                        xpeak = 14. + xrel - xoff if xoff is not None else xctr
-                        for yoff in off:
-                            y0 = 511 + yoff if yoff is not None else None
-                            ypeak = 14. + yrel - yoff if yoff is not None else yctr
-
-                            t0 = time.perf_counter()
-                            clip = psf.get_stamp( 1023 + xrel, 511 + yrel, x0=x0, y0=y0 )
-                            t += time.perf_counter() - t0
-                            n += 1
-                            assert clip.shape == ( 29, 29 )
-                            cy, cx = scipy.ndimage.center_of_mass( clip )
-                            assert cx == pytest.approx( xpeak, abs=0.01 )
-                            assert cy == pytest.approx( ypeak, abs=0.01 )
-
-    SNLogger.debug( f"test_get_stamp_offset_oversampled: average get_stamp runtime: {t/n} over {n} runs" )
+    def test_get_stamp_offset_oversampled( self ):
+        self.run_test_get_stamp_offset_oversampled()

--- a/snappl/tests/test_photutilsimagepsf.py
+++ b/snappl/tests/test_photutilsimagepsf.py
@@ -51,7 +51,7 @@ def make_psf_for_test_stamp( x=1023, y=511, oversamp=3, sigmax=1.2, sigmay=None 
     # 5× oversampled means a 145×145 data array.  145 // 2 = 72
 
     sigmay = sigmax if sigmay is None else sigmay
-    
+
     assert isinstance( oversamp, int )
     size = int( np.ceil( oversamp * 29 ) )
     size += 1 if size % 2 == 0 else 0
@@ -81,7 +81,7 @@ def test_get_stamp_orientation():
     assert cx == pytest.approx( 14., abs=0.01 )
     import pdb; pdb.set_trace()
     pass
-    
+
 # "centered" here means the original PSF is centered; we're going to
 #   render it offset
 def test_get_stamp_centered_oversampled():
@@ -116,6 +116,8 @@ def test_get_stamp_centered_oversampled():
     #   This is as documented in snappl.psf.PSF.get_stamp
     relpos = [ -2.5, -1.8, -1.4, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 1.0, 1.4,   1.8,  2.5 ]
     ctrexp = [ 13.5, 14.2, 13.6,   14., 14.2, 13.9, 14., 14.1, 13.8, 14., 14.4, 13.8, 13.5 ]
+    # relpos = [ -1.8, -1.4, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 1.0, 1.4,   1.8 ]
+    # ctrexp = [ 14.2, 13.6,   14., 14.2, 13.9, 14., 14.1, 13.8, 14., 14.4, 13.8 ]
 
     for xrel, xctr in zip( relpos, ctrexp ):
         for yrel, yctr in zip( relpos, ctrexp ):
@@ -186,7 +188,7 @@ def test_get_stamp_centered_oversampled():
 
     import pdb; pdb.set_trace()
     pass
-    
+
     # Test a whole bunch in a four-loop.  When off is None then we
     #   expect the PSF to be centered on the clip at xctr, yctr (pulled
     #   from the ctrpos array), just as in tests above where we didn't

--- a/snappl/tests/test_photutilsimagepsf.py
+++ b/snappl/tests/test_photutilsimagepsf.py
@@ -1,362 +1,71 @@
-
 import pytest
-import time
-
 import numpy as np
-import scipy
-from astropy.io import fits
+
+import sys
+sys.path.insert( 0, '.' )
+from base_testimagepsf import BaseTestImagePSF
 
 from snappl.psf import PSF, photutilsImagePSF
-from snpit_utils.logger import SNLogger
 
 
-@pytest.fixture
-def testpsf():
-    loaded = np.load('psf_test_data/testpsfarray.npz')
-    arr = loaded['args']
-    mypsf = PSF.get_psf_object( "photutilsImagePSF", data=arr, x=3832., y=255., oversample_factor=3., normalize=True )
-    return mypsf
+class TestPhotutilsImagePSF( BaseTestImagePSF ):
+    __psfclass__ = photutilsImagePSF
 
+    @pytest.fixture
+    def testpsf( self ):
+        loaded = np.load('psf_test_data/testpsfarray.npz')
+        arr = loaded['args']
+        mypsf = PSF.get_psf_object( "photutilsImagePSF", data=arr, x=3832., y=255.,
+                                    oversample_factor=3., normalize=True )
+        assert isinstance( mypsf, self.__psfclass__ )
+        return mypsf
 
-def test_create( testpsf ):
-    assert isinstance( testpsf, photutilsImagePSF )
-    assert testpsf._data.sum() == pytest.approx( 1., rel=1e-9 )
-    # data array was 77×77, we are oversampled by 3x, so nominally
-    #  it's 25.7×25.7 on the image.  But, the array size is an integer,
-    #  and it floors, so we should get 25
-    assert testpsf.stamp_size == 25
-    assert testpsf.clip_size == 25
-    assert testpsf.oversample_factor == 3
-    assert testpsf.x == 3832.
-    assert testpsf.y == 255.
-    loaded = np.load( 'psf_test_data/testpsfarray.npz' )
-    arr = loaded['args']
-    assert np.all( arr / arr.sum() == testpsf.oversampled_data )
-    # TODO : test that normalize=False works
+    def make_psf_for_test_stamp( self, x=1023, y=511, oversamp=3, sigmax=1.2, sigmay=None ):
+        # Make a 3x oversampled PSF that's a gaussian with sigma 1.2 (in
+        # image pixel units, not oversampled units).  2√(2ln2)*1.2 = FWHM of
+        # 2.83, so for a radius of 5 FWHMs (to be really anal), we want a
+        # 29×29 stamp in image units.
+        #
+        # 3× oversampled means an 87×87 data array.  87 // 2 = 43
+        # 5× oversampled means a 145×145 data array.  145 // 2 = 72
 
+        sigmay = sigmax if sigmay is None else sigmay
 
-@pytest.mark.skip( reason="Comment out the skip to write some files for visual inspection" )
-def test_interactive_write_stamp_to_fits_for_visual_inspection( testpsf ):
-    fits.writeto( 'test_deleteme_orig.fits', testpsf._data, overwrite=True )
-    fits.writeto( 'test_deleteme_resamp.fits', testpsf.get_stamp(), overwrite=True )
+        assert isinstance( oversamp, int )
+        size = int( np.ceil( oversamp * 29 ) )
+        size += 1 if size % 2 == 0 else 0
+        ctr = size // 2
 
+        # If there's a fractional part of x or y, for snappl that means that the
+        #   PSF will be offset from center by that much.  To handle such
+        #   intrinsically-offcenter PSFs in snappl, we always center
+        #   the PSF on the oversampled array (unless we pass peakx,
+        #   peaky, which we aren't here).
+        xvals = np.arange( -ctr, ctr+1 )
+        yvals = np.arange( -ctr, ctr+1 )
+        ovsigmax = oversamp * sigmax
+        ovsigmay = oversamp * sigmay
+        data = np.exp( -( xvals[np.newaxis,:]**2 / ( 2. * ovsigmax**2 ) +
+                          yvals[:,np.newaxis]**2 / ( 2. * ovsigmay**2 ) ) )
+        data /= data.sum()
+        psf = PSF.get_psf_object( "photutilsImagePSF", data=data, x=x, y=y, oversample_factor=oversamp )
 
-def make_psf_for_test_stamp( x=1023, y=511, oversamp=3, sigmax=1.2, sigmay=None ):
-    # Make a 3x oversampled PSF that's a gaussian with sigma 1.2 (in
-    # image pixel units, not oversampled units).  2√(2ln2)*1.2 = FWHM of
-    # 2.83, so for a radius of 5 FWHMs (to be really anal), we want a
-    # 29×29 stamp in image units.
-    #
-    # 3× oversampled means an 87×87 data array.  87 // 2 = 43
-    # 5× oversampled means a 145×145 data array.  145 // 2 = 72
+        datacx = size // 2
+        datacy = size // 2
 
-    sigmay = sigmax if sigmay is None else sigmay
+        return psf, datacx, datacy
 
-    assert isinstance( oversamp, int )
-    size = int( np.ceil( oversamp * 29 ) )
-    size += 1 if size % 2 == 0 else 0
-    ctr = size // 2
+    def test_get_stamp_orientation( self ):
+        self.run_test_get_stamp_orientation()
 
-    xvals = np.arange( -ctr, ctr+1 ) + oversamp * ( np.floor( x + 0.5 ) - x )
-    yvals = np.arange( -ctr, ctr+1 ) + oversamp * ( np.floor( y + 0.5 ) - y )
-    ovsigmax = oversamp * sigmax
-    ovsigmay = oversamp * sigmay
-    data = np.exp( -( xvals[np.newaxis,:]**2 / ( 2. * ovsigmax**2 ) +
-                      yvals[:,np.newaxis]**2 / ( 2. * ovsigmay**2 ) ) )
-    data /= data.sum()
-    psf = PSF.get_psf_object( "photutilsImagePSF", data=data, x=x, y=y, oversample_factor=oversamp )
+    def test_get_stamp_centered_oversampled( self ):
+        self.run_test_get_stamp_centered_oversampled()
 
-    return psf
+    @pytest.mark.xfail( reason="We know this doesn't work right yet." )
+    def test_get_stamp_centered_oversampled_with_undersampled_psf( self ):
+        self.run_test_get_stamp_centered_oversampled( oversamp=3, sigma=0.3 )
 
+    def test_get_stamp_offset_oversampled( self ):
+        self.run_test_get_stamp_offset_oversampled()
 
-def test_get_stamp_orientation():
-    oversamp = 3
-    sigmax = 1.2
-    sigmay = 2.4
-    psf = make_psf_for_test_stamp( oversamp=oversamp, sigmax=sigmax, sigmay=sigmay )
-    clip = psf.get_stamp()
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cy == pytest.approx( 14., abs=0.01 )
-    assert cx == pytest.approx( 14., abs=0.01 )
-    import pdb; pdb.set_trace()
-    pass
-
-# "centered" here means the original PSF is centered; we're going to
-#   render it offset
-def test_get_stamp_centered_oversampled():
-    oversamp = 3
-    sigma = 1.2
-    psf = make_psf_for_test_stamp( oversamp=oversamp, sigmax=sigma )
-
-    # If we just get_stamp(), we should get a 29×29 image centered on the middle
-    # We don't actually really expect the stamp to be exactly expectedgauss, because
-    #   the interpolation in get_stamp() is more sophisticated than just "evaluate
-    #   the gaussian at the point".  We should be oversampled enough, though, that
-    #   it's damn close.
-    clipx = np.arange( -14, 15 )
-    clipy = np.arange( -14, 15 )
-    expectedgauss = np.exp( -( clipx[np.newaxis,:]**2 + clipy[:,np.newaxis]**2 ) / ( 2. * sigma**2 ) )
-    expectedgauss /= expectedgauss.sum()
-    clip = psf.get_stamp()
-    assert clip.shape == ( 29, 29 )
-    assert clip.sum() == pytest.approx( 1, abs=0.005 )
-    # Doing an absolute, not a relative, comparison because where the gaussian is
-    #   approximately zero, we don't need it to be identically 0
-    assert np.all( clip == pytest.approx( expectedgauss, abs=0.001 / ( 29*29 ) ) )
-
-    # Render a bunch that are offset and make sure they center up where
-    # expected
-
-    # When the relative position is offset by an integer from the place
-    #   we evaluted the pixel at ((1023, 511) in this case), the PSF
-    #   should still be centered on the center pixel of the image.
-    # NOTICE : when the fractional part is exactly 0.5, the PSF is
-    #   centered down and to the left of the center pixel of the clip.
-    #   This is as documented in snappl.psf.PSF.get_stamp
-    relpos = [ -2.5, -1.8, -1.4, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 1.0, 1.4,   1.8,  2.5 ]
-    ctrexp = [ 13.5, 14.2, 13.6,   14., 14.2, 13.9, 14., 14.1, 13.8, 14., 14.4, 13.8, 13.5 ]
-    # relpos = [ -1.8, -1.4, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 1.0, 1.4,   1.8 ]
-    # ctrexp = [ 14.2, 13.6,   14., 14.2, 13.9, 14., 14.1, 13.8, 14., 14.4, 13.8 ]
-
-    for xrel, xctr in zip( relpos, ctrexp ):
-        for yrel, yctr in zip( relpos, ctrexp ):
-            clip = psf.get_stamp( 1023 + xrel, 511 + yrel )
-            assert clip.sum() == pytest.approx( 1, abs=0.005 )
-            assert clip.shape == ( 29, 29 )
-            cy, cx = scipy.ndimage.center_of_mass( clip )
-            assert cx == pytest.approx( xctr, abs=0.01 )
-            assert cy == pytest.approx( yctr, abs=0.01 )
-
-    # Now try the case where we pass x0 and y0 to get_stamp.
-
-    # A handful of specific cases with non-None x0 and y0 to help the
-    #   writer of this test think about all the upcoming for loops.
-
-    # First case: we have a PSF that we want centered three pixels up
-    #   and to the right.  We'll pass x0 and y0 as (1023, 511) (which is
-    #   the default), and then give x and y as 1026 and 514.  This is *different*
-    #   from x=1026, y=514, x0=None, y=None; in that case the PSF would be
-    #   centered, because it would determine a different x0 and y0 from what
-    #   we pass in this example.
-
-    clip = psf.get_stamp( 1026., 514., x0=1023, y0=511 )
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    assert clip.shape == ( 29, 29 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cx == pytest.approx( 14.+3., abs=0.01 )
-    assert cy == pytest.approx( 14.+3., abs=0.01 )
-    # Uncomment for visual debugging
-    # fits.writeto( "test_get_stamp_centered_oversampled_1.fits", clip, overwrite=True )
-
-    # Second case: we're going to put the psf at its standard position
-    # of 1023, 511, but then we want the center of the clip to
-    # correspond to 1022, 512 on the image.  So, the PSF should be one
-    # pixel to the right and one pixel down.
-
-    clip = psf.get_stamp( 1023., 511., x0=1022, y0=512 )
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    assert clip.shape == ( 29, 29 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cx == pytest.approx( 14.+1., abs=0.01 )
-    assert cy == pytest.approx( 14.-1., abs=0.01 )
-    # Uncomment for visual debugging
-    # fits.writeto( "test_get_stamp_centered_oversampled_2.fits", clip, overwrite=True )
-
-    # Third case: if we just ask for (x=1023.5, y=511.5), we'll get a
-    # PSF centered down and to the left of the center of the clip,
-    # because of the whole floor thing.  However, if we also give
-    # x0=1023, y0=511, then we should get a PSF centered up and to the
-    # right.
-
-    clip = psf.get_stamp( 1023.5, 511.5 )
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    assert clip.shape == ( 29, 29 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cx == pytest.approx( 14.-0.5, abs=0.01 )
-    assert cy == pytest.approx( 14.-0.5, abs=0.01 )
-    # Uncomment for visual debugging
-    # fits.writeto( "test_get_stamp_centered_oversampled_3.fits", clip, overwrite=True )
-    clip = psf.get_stamp( 1023.5, 511.5, x0=1023, y0=511 )
-    assert clip.sum() == pytest.approx( 1., abs=0.005 )
-    assert clip.shape == ( 29, 29 )
-    cy, cx = scipy.ndimage.center_of_mass( clip )
-    assert cx == pytest.approx( 14.+0.5, abs=0.01 )
-    assert cy == pytest.approx( 14.+0.5, abs=0.01 )
-    # Uncomment for visual debugging
-    # fits.writeto( "test_get_stamp_centered_oversampled_4.fits", clip, overwrite=True )
-
-    import pdb; pdb.set_trace()
-    pass
-
-    # Test a whole bunch in a four-loop.  When off is None then we
-    #   expect the PSF to be centered on the clip at xctr, yctr (pulled
-    #   from the ctrpos array), just as in tests above where we didn't
-    #   pass x0 and y0.  Otherwise, it depends on both x and x0 (or y
-    #   and y0 as appropriate).
-    relpos = [ -2.5, -0.8,  0.,  0.1,  1.4,  1.5 ]
-    ctrpos = [ 13.5, 14.2, 14., 14.1, 14.4, 13.5 ]
-    off = [ -15, -1, 0, None, 3, 12 ]
-    numnear = 0
-    numnearish = 0
-    numnotnear = 0
-    punted = 0
-    for xrel, xctr in zip( relpos, ctrpos ):
-        for yrel, yctr in zip( relpos, ctrpos ):
-            for xoff in off:
-                x0 = 1023 + xoff if xoff is not None else None
-                xpeak = 14. + xrel - xoff if xoff is not None else xctr
-                for yoff in off:
-                    y0 = 511 + yoff if yoff is not None else None
-                    ypeak = 14. + yrel - yoff if yoff is not None else yctr
-
-                    clip = psf.get_stamp( 1023+xrel, 511+yrel, x0=x0, y0=y0 )
-                    assert clip.shape == ( 29, 29 )
-                    # ****
-                    # For visual debugging.  Warning: writes a metric butt-ton of images.
-                    # fits.writeto( f'deteleme_{xrel}_{yrel}_{xoff}_{yoff}.fits', clip, overwrite=True )
-                    # ****
-
-                    # If xpeak or ypeak is too close to the edge, then we don't
-                    #   expect the sum to be 1, because flux will have slopped
-                    #   off of the edge of the clip.  Also, finding the
-                    #   center is fraught; scipy.ndiamge.center_of_mass won't
-                    #   give us the center, because all the missing flux is
-                    #   going to make the formal centroid offset towards
-                    #   the center from the peak.  In that case, satisfy
-                    #   ourself with making sure that the nominal peak
-                    #   pixel is brighter than its neighbors.  (Well...
-                    #   except when the fractional part relpos is 0.5, and
-                    #   then we look at the two (or four) brightest pixels.)
-                    nearishedge = ( xpeak < 3. ) or ( xpeak > 25. ) or ( ypeak < 3. ) or ( ypeak > 25. )
-                    nearedge = ( ( ( xpeak < 2. ) or ( xpeak > 26. ) or ( ypeak < 2. ) or ( ypeak > 26. ) )
-                                 or
-                                 ( ( ( xpeak < 3. ) or ( xpeak > 25. ) )
-                                   and
-                                   ( ( ypeak < 3. ) or ( ypeak > 25. ) )
-                                  )
-                                )
-                    if nearedge:
-                        numnear += 1
-                        assert clip.sum() < 0.98
-                        ixpeak = int( np.floor( xpeak + 0.5 ) )
-                        iypeak = int( np.floor( ypeak + 0.5 ) )
-                        # We're just gonna punt if the peak is off of the edge of the image
-                        if ( iypeak >= 1 ) and ( iypeak <= 27 ) and ( ixpeak >= 1 ) and ( ixpeak <= 27 ):
-                            if ( ixpeak - xpeak == 0.5 ) and ( iypeak - ypeak == 0.5 ):
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak-1, ixpeak], rel=1e-5 )
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak, ixpeak-1], rel=1e-5 )
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[iypeak-1, ixpeak-1], rel=1e-5 )
-                            elif ixpeak - xpeak == 0.5:
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[ iypeak, ixpeak-1], rel=1e-5 )
-                                assert clip[iypeak+1, ixpeak] < clip[iypeak, ixpeak]
-                                assert clip[iypeak-1, ixpeak] < clip[iypeak, ixpeak]
-                                assert clip[iypeak+1, ixpeak-1] < clip[iypeak, ixpeak]
-                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
-                            elif iypeak - ypeak == 0.5:
-                                assert clip[iypeak, ixpeak] == pytest.approx( clip[ iypeak-1, ixpeak], rel=1e-5 )
-                                assert clip[iypeak, ixpeak+1] < clip[iypeak, ixpeak]
-                                assert clip[iypeak, ixpeak-1] < clip[iypeak, ixpeak]
-                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
-                                assert clip[iypeak-1, ixpeak-1] < clip[iypeak, ixpeak]
-                            else:
-                                assert clip[iypeak, ixpeak] > clip[iypeak-1, ixpeak]
-                                assert clip[iypeak, ixpeak] > clip[iypeak+1, ixpeak]
-                                assert clip[iypeak, ixpeak] > clip[iypeak, ixpeak+1]
-                                assert clip[iypeak, ixpeak] > clip[iypeak, ixpeak-1]
-                        else:
-                            punted += 1
-                    else:
-                        cy, cx = scipy.ndimage.center_of_mass( clip )
-                        if nearishedge:
-                            numnearish += 1
-                            assert clip.sum() == pytest.approx( 0.99, abs=0.01 )
-                            assert cx == pytest.approx( xpeak, abs=0.06 )
-                            assert cy == pytest.approx( ypeak, abs=0.06 )
-                        else:
-                            numnotnear += 1
-                            assert clip.sum() == pytest.approx( 1., abs=0.005 )
-                            assert cx == pytest.approx( xpeak, abs=0.01 )
-                            assert cy == pytest.approx( ypeak, abs=0.01 )
-
-    SNLogger.debug( f"test_get_stamp_centered_oversampled: {numnear} near edge ({punted} punted), {numnearish} "
-                    f"nearish edge, {numnotnear} not near edge" )
-
-
-# Test the scary case where we pass a PSF that's not centered on its natural clip.
-# (Why would you DO that?)
-def test_get_stamp_offset_oversampled():
-
-    oversamp = 3
-    sigma = 1.2
-    n = 0
-    t = 0
-
-    psfposfracs = [ 0.3792, 0., 0.5, 0.8 ]
-    for xposfrac in psfposfracs:
-        xpos = 1023 + xposfrac
-        for yposfrac in psfposfracs:
-            ypos = 511 + yposfrac
-            psf = make_psf_for_test_stamp( xpos, ypos, oversamp=oversamp, sigmax=sigma )
-            # Make sure the raw data array we passed is at the right spot
-            xround = np.floor( xpos + 0.5 )
-            yround = np.floor( ypos + 0.5 )
-            cy, cx = scipy.ndimage.center_of_mass( psf.oversampled_data )
-            assert cy == pytest.approx( ( 29 * oversamp ) // 2 + (ypos-yround) * oversamp, abs=0.01*oversamp )
-            assert cx == pytest.approx( ( 29 * oversamp ) // 2 + (xpos-xround) * oversamp, abs=0.01*oversamp )
-
-
-            # If we just get_stamp(), it will get it at the x, y we created with
-            t0 = time.perf_counter()
-            clip = psf.get_stamp()
-            t += time.perf_counter() - t0
-            n += 1
-            assert clip.shape == ( 29, 29 )
-            cy, cx = scipy.ndimage.center_of_mass( clip )
-            assert cx == pytest.approx( 14. + (xpos-xround), abs=0.01 )
-            assert cy == pytest.approx( 14. + (ypos-yround), abs=0.01 )
-
-
-            relpos = [ -2.5, -1.0,  -0.8, -0.1,  0.,  0.1,  0.8, 2.5 ]
-            ctrexp = [ 13.5,  14.,  14.2, 13.9, 14., 14.1, 13.8, 13.5 ]
-            # OMG, N⁴
-            for xrel, xctr in zip( relpos, ctrexp ):
-                for yrel, yctr in zip( relpos, ctrexp ):
-                    clip = psf.get_stamp( 1023 + xrel, 511 + yrel )
-                    assert clip.shape == ( 29, 29 )
-                    cy, cx = scipy.ndimage.center_of_mass( clip )
-                    assert cx == pytest.approx( xctr, abs=0.01 )
-                    assert cy == pytest.approx( yctr, abs=0.01 )
-
-    # OMGOMG, N⁶
-    # (Minimize number of cases, and don't bother testing near-the-edge
-    #  stuff that got tested for intrinsically centered psfs.)
-    psfposfracs = [ 0.3792, 0.8 ]
-    for xposfrac in psfposfracs:
-        xpos = 1023 + xposfrac
-        for yposfrac in psfposfracs:
-            ypos = 511 + yposfrac
-            psf = make_psf_for_test_stamp( xpos, ypos, oversamp=oversamp, sigmax=sigma )
-
-            relpos = [ -2.5, -0.1,  0.2 ]
-            ctrexp = [ 13.5, 13.9, 14.2 ]
-            off = [ -3, 0, None, 2 ]
-            for xrel, xctr in zip( relpos, ctrexp ):
-                for yrel, yctr in zip( relpos, ctrexp ):
-                    for xoff in off:
-                        x0 = 1023 + xoff if xoff is not None else None
-                        xpeak = 14. + xrel - xoff if xoff is not None else xctr
-                        for yoff in off:
-                            y0 = 511 + yoff if yoff is not None else None
-                            ypeak = 14. + yrel - yoff if yoff is not None else yctr
-
-                            t0 = time.perf_counter()
-                            clip = psf.get_stamp( 1023 + xrel, 511 + yrel, x0=x0, y0=y0 )
-                            t += time.perf_counter() - t0
-                            n += 1
-                            assert clip.shape == ( 29, 29 )
-                            cy, cx = scipy.ndimage.center_of_mass( clip )
-                            assert cx == pytest.approx( xpeak, abs=0.01 )
-                            assert cy == pytest.approx( ypeak, abs=0.01 )
-
-    SNLogger.debug( f"test_get_stamp_offset_oversampled: average get_stamp runtime: {t/n} over {n} runs" )
+    # TODO more undersampled tests

--- a/snappl/tests/test_wcs.py
+++ b/snappl/tests/test_wcs.py
@@ -31,7 +31,7 @@ def test_astropywcs( ou2024image, check_wcs ):
     assert wcs._wcs_is_astropy
     check_wcs( wcs )
 
-    
+
 def test_galsimwcs( ou2024image, check_wcs ):
     # Again, naughty use of _get_header
     wcs = GalsimWCS.from_header( ou2024image._get_header() )
@@ -59,7 +59,7 @@ def test_get_astropywcs_get_galsimwcs( ou2024image, check_wcs ):
     gswcs = GalsimWCS( rawgswcs )
     check_wcs( gswcs )
 
-    
+
 def test_if_wcs_invertible(ou2024image):
     # OpenUniverse Images are in fk5 coordinates, i.e. they use
     # EQUINOX = 2000.0, but astropy SkyCoord defaults to ICRS.
@@ -78,4 +78,3 @@ def test_if_wcs_invertible(ou2024image):
     x_y_pixel = wcs.world_to_pixel(ra_dec[0], ra_dec[1])
     assert np.abs(x_y_pixel[0]) < 1e-9, 'x coordinate did not invert properly'
     assert np.abs(x_y_pixel[1]) < 1e-9, 'y coordinate did not invert properly'
-

--- a/snappl/tests/test_yaml_serialized_oversampled_image_psf.py
+++ b/snappl/tests/test_yaml_serialized_oversampled_image_psf.py
@@ -5,14 +5,16 @@ import pytest
 
 import numpy as np
 
-from snappl.psf import YamlSerialized_OversampledImagePSF
+from snappl.psf import PSF, YamlSerialized_OversampledImagePSF
 
 
 @pytest.fixture
 def testpsf():
     loaded = np.load('psf_test_data/testpsfarray.npz')
     arr = loaded['args']
-    mypsf = YamlSerialized_OversampledImagePSF.create( arr, 3832., 255., oversample_factor=3. )
+    arr /= arr.sum()
+    mypsf = PSF.get_psf_object( "YamlSerialized_OversampledImagePSF", data=arr, x=3832., y=255., oversample_factor=3. )
+    assert isinstance( mypsf, YamlSerialized_OversampledImagePSF )
     return mypsf
 
 
@@ -38,7 +40,7 @@ def test_read( testpsf ):
     try:
         testpsf.write( barf )
 
-        bpsf = YamlSerialized_OversampledImagePSF()
+        bpsf = PSF.get_psf_object( "YamlSerialized_OversampledImagePSF", x=0., y=0. )
         bpsf.read( barf )
         assert bpsf._x == 3832.
         assert bpsf._y == 255.


### PR DESCRIPTION
Addresses Issue #12, Issue #19 (in the doc string), Issue #32 ; introduces Issue #30 (which was there before, but now we know it).

This started with letting `PSF.get_stamp()` support off-centered PSFs, as Cole needed that for what he's doing.  Lots of long docstrings were written.

In so doing, I found a few rabbit holes that I went down.  First, knowing that doing galsim photon ops over and over would be slow, I renamed the `ou24PSF` class to `ou24PSF_slow`, and started writing an `ou24PSF` class.  That code is all commented now, as I did not get far before other rabbit holes reared their head.  Leaving the commented code in there because it may be useful in the future as we continue this effort.

The next rabbit hole I ran into is summarized in Issue #30.  To that end, I added the `photutilsImagePSF` class, hoping that it would not have the interpolation errors* that we have in OversampledImagePSF, but, as documented in Issue #30, they do.

I refactored some tests because `photutilsImagePSF` and `OversampledImagePSF` tests had a lot of code in common.  We now have some object-oriented tests.

I added tests for `ou24PSF` (now `ou24PSF_slow`) because we didn't have them before.

