### PR TITLE
Allow snappl to handle partial cutouts. 

### DIFF
--- a/snappl/image.py
+++ b/snappl/image.py
@@ -638,6 +638,9 @@ class FITSImage( Numpy2DImage ):
         apwcs = None if wcs is None else wcs._wcs
 
         # Remember that numpy arrays are indexed [y, x] (at least if they're read with astropy.io.fits)
+        if "mode" not in kwargs:
+            kwargs['mode'] = 'strict'
+
         astropy_cutout = Cutout2D(data, (x, y), size=(ysize, xsize), wcs=apwcs, **kwargs)
         astropy_noise = Cutout2D(noise, (x, y), size=(ysize, xsize), wcs=apwcs, **kwargs)
         # Because flags are integer, we can't use the same fill_value as the default.


### PR DESCRIPTION
See campari [PR 158](https://github.com/Roman-Supernova-PIT/campari/pull/158)
Here we allow for get_ra_dec_cutout and get_cutout to be used in modes other than "strict" if the user so chooses. 