### PR TITLE
Bug fix in band determination in STPSF class

### DIFF
--- a/changes/190.snappl.rst
+++ b/changes/190.snappl.rst
@@ -1,0 +1,1 @@
+Fixes a bug in which the input band for STPSF is ignored.

--- a/snappl/psf.py
+++ b/snappl/psf.py
@@ -1856,7 +1856,9 @@ class STPSF( PSF ):
 
         wfi = stpsf.roman.WFI()
         wfi.detector = f"WFI{self._sca:02d}"
-        wfi.filter = self._band # wfi defaults to F062, so we must set it manually.
+
+        wfi_band = "F" + self._band[1:] if not self._band.startswith("F") else self._band
+        wfi.filter = wfi_band
 
         # If a position is not given, assume the middle of the SCA
         #   (within 1/2 pixel; by default, we want to make x and y

--- a/snappl/psf.py
+++ b/snappl/psf.py
@@ -1791,7 +1791,6 @@ class STPSF( PSF ):
         super().__init__( _parent_class=True, **kwargs )
         self._consumed_args.update( [ 'sed', 'size' ] )
         self._warn_unknown_kwargs( kwargs, _parent_class=_parent_class )
-
         if self._band is None:
             try:
                 self._band = self._image.band
@@ -1857,6 +1856,7 @@ class STPSF( PSF ):
 
         wfi = stpsf.roman.WFI()
         wfi.detector = f"WFI{self._sca:02d}"
+        wfi.filter = self._band # wfi defaults to F062, so we must set it manually.
 
         # If a position is not given, assume the middle of the SCA
         #   (within 1/2 pixel; by default, we want to make x and y

--- a/snappl/psf.py
+++ b/snappl/psf.py
@@ -1857,7 +1857,26 @@ class STPSF( PSF ):
         wfi = stpsf.roman.WFI()
         wfi.detector = f"WFI{self._sca:02d}"
 
-        wfi_band = "F" + self._band[1:] if not self._band.startswith("F") else self._band
+        band_dict = {
+        "F062": "F062",
+        "F087": "F087",
+        "F106": "F106",
+        "F129": "F129",
+        "F158": "F158",
+        "F184": "F184",
+        "F213": "F213",
+        "R062": "F062",
+        "Z087": "F087",
+        "Y106": "F106",
+        "J129": "F129",
+        "H158": "F158",
+        "K213": "F213",
+    }
+
+        wfi_band = band_dict.get(self._band, None)
+        if wfi_band is None:
+            raise ValueError(f"Band {self._band} not recognized for STPSF generation."
+                             f" Recognized bands are: {list(band_dict.keys())}")
         wfi.filter = wfi_band
 
         # If a position is not given, assume the middle of the SCA

--- a/snappl/tests/test_stpsf.py
+++ b/snappl/tests/test_stpsf.py
@@ -12,7 +12,7 @@ def test_normalization():
     and that smaller stamps have a normalization such that they
     match the sum of the subset of the big PSF stamp.
     """
-    bigsize = 501
+    bigsize = 1001
     mediumsize = 201
     smallsize = 41
     # Using the same seed here probably isn't doing what we want it to do,
@@ -49,13 +49,13 @@ def test_get_centered_psf():
     # Try a basic centered PSF
     stamp = psfobj.get_stamp(seed=42)
     assert stamp.shape == (41, 41)
-    # 2026-02-14 MWV: H158 comes out to 0.979.  See test_normalization for implicit comparison.
-    assert stamp.sum() == pytest.approx(0.979, abs=0.001)
+    # 2026-02-14 MWV: H158 comes out to 0.960.  See test_normalization for implicit comparison.
+    assert stamp.sum() == pytest.approx(0.960, abs=0.001)
 
     cy, cx = scipy.ndimage.center_of_mass(stamp)
     # The roman PSF is asymmetric, so we don't expect the CoM to be the exact center.
-    # The comparison numbers are what MWV go when adapting this test for STPSF
-    assert cx == pytest.approx(19.856, abs=0.01)
+    # The comparison numbers are what MWV got when adapting this test for STPSF
+    assert cx == pytest.approx(19.882, abs=0.01)
     assert cy == pytest.approx(19.911, abs=0.01)
 
 
@@ -76,7 +76,7 @@ def test_get_offcenter_psf():
     # Reversed because we're directly looking at the ndarray which is y, x
     cy, cx = scipy.ndimage.center_of_mass(stamp)
     assert cx == pytest.approx(19.856 + (x - x0), abs=0.2)
-    assert cy == pytest.approx(19.911 + (y - y0), abs=0.2)
+    assert cy == pytest.approx(19.696 + (y - y0), abs=0.2)
 
     # This stamp should just be a shifted version of centerstamp; verify
     #   that.  This check should be much more precise than the
@@ -97,7 +97,7 @@ def test_get_edge_centered_psf():
     psfobj = PSF.get_psf_object("STPSF", band="H158", sca=17, size=41.0)
     stamp = psfobj.get_stamp(2048.5, 2048.0, seed=42)
     assert stamp.shape == (41, 41)
-    assert stamp.sum() == pytest.approx(0.979, abs=0.001)
+    assert stamp.sum() == pytest.approx(0.960, abs=0.001)
 
     cy, cx = scipy.ndimage.center_of_mass(stamp)
     assert cx == pytest.approx(19.40, abs=0.02)
@@ -111,11 +111,11 @@ def test_get_corner_centered_psf():
     psfobj = PSF.get_psf_object("STPSF", band="H158", sca=17, size=41.0)
     stamp = psfobj.get_stamp(2048.5, 2048.5, seed=42)
     assert stamp.shape == (41, 41)
-    assert stamp.sum() == pytest.approx(0.979, abs=0.001)
+    assert stamp.sum() == pytest.approx(0.960, abs=0.001)
 
     cy, cx = scipy.ndimage.center_of_mass(stamp)
     assert cx == pytest.approx(19.40, abs=0.02)
-    assert cy == pytest.approx(19.45, abs=0.02)
+    assert cy == pytest.approx(19.42, abs=0.02)
 
 
 def test_get_offset_corner_centered_psf():
@@ -129,7 +129,7 @@ def test_get_offset_corner_centered_psf():
 
     cy, cx = scipy.ndimage.center_of_mass(stamp)
     assert cx == pytest.approx(18.40, abs=0.02)
-    assert cy == pytest.approx(22.40, abs=0.03)
+    assert cy == pytest.approx(22.34, abs=0.03)
 
 
 def test_get_offset_psf():
@@ -140,4 +140,4 @@ def test_get_offset_psf():
 
     cy, cx = scipy.ndimage.center_of_mass(stamp)
     assert cx == pytest.approx(20.05, abs=0.05)
-    assert cy == pytest.approx(19.8, abs=0.05)
+    assert cy == pytest.approx(19.71, abs=0.05)


### PR DESCRIPTION
The WFI object has a default band which was being used instead of what was passed.

This meant that regression tests needed to be updated. Also, since the band in the tests is now H band instead of the erroneous R band, the size of the big stamp needed to be increased significantly to attain a total flux of approximately 1.