### PR TITLE
update gh pages deploy workflow 

### DIFF
--- a/.github/workflows/sphinx-deploy.yml
+++ b/.github/workflows/sphinx-deploy.yml
@@ -13,12 +13,12 @@ jobs:
       contents: write
     steps:
     - id: deployment
-      uses: sphinx-notes/pages@23ef64097ef9b00d8f71e978bc518ee32ca98651  # v3.2
+      uses: sphinx-notes/pages@6e3e0108e79636a0908b1c2c5899e0d3dfad0bc1  # v3.6
       with:
         publish: false
         documentation_path: ./docs
         pyproject_extras: docs
-    - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
+    - uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ${{ steps.deployment.outputs.artifact }} 

--- a/changes/194.bugfix.rst
+++ b/changes/194.bugfix.rst
@@ -1,0 +1,1 @@
+update the action versions for github pages deploy


### PR DESCRIPTION
update the pages deploy to latest versions of the actions. Worth a try for the issue with stalling deploy