### PR TITLE
Implement self.free() for Romandatamodelimage

### DIFF
--- a/changes/200.feature.rst
+++ b/changes/200.feature.rst
@@ -1,0 +1,1 @@
+Implement self.free for RomanDatamodelImage.

--- a/snappl/image.py
+++ b/snappl/image.py
@@ -2511,6 +2511,11 @@ class RomanDatamodelImage( Image ):
         else:
             raise TypeError("Flags must be a 2d numpy array of integers.")
 
+    def free( self ):
+        self._data = None
+        self._noise = None
+        self._flags = None
+
 # ======================================================================
 # This dictionary defines the format field in the database.  The key is the format
 #   integer, the value gives the image class, the base path config value, and eventually

--- a/snappl/image.py
+++ b/snappl/image.py
@@ -2512,6 +2512,9 @@ class RomanDatamodelImage( Image ):
             raise TypeError("Flags must be a 2d numpy array of integers.")
 
     def free( self ):
+        SNLogger.warning( 'WARNING: self.free() has been called for the RomanDatamodelImage class. \
+                           This does not actually free memory. This function is included for \
+                           compatibility reasons.' )
         self._data = None
         self._noise = None
         self._flags = None

--- a/snappl/tests/test_image.py
+++ b/snappl/tests/test_image.py
@@ -844,3 +844,9 @@ def test_romandatamodel_set_data( romandatamodel_image ):
         image.flags = origim
     with pytest.raises( TypeError, match="Flags must be a 2d numpy array of integers." ):
         image.flags = np.array( [1, 2, 3] )
+
+    # Also test self.free(). 
+    image.free()
+    assert image._data is None
+    assert image._noise is None
+    assert image._flags is None

--- a/snappl/tests/test_image.py
+++ b/snappl/tests/test_image.py
@@ -845,7 +845,7 @@ def test_romandatamodel_set_data( romandatamodel_image ):
     with pytest.raises( TypeError, match="Flags must be a 2d numpy array of integers." ):
         image.flags = np.array( [1, 2, 3] )
 
-    # Also test self.free(). 
+    # Also test self.free().
     image.free()
     assert image._data is None
     assert image._noise is None


### PR DESCRIPTION
phrosty uses this to save memory. Needed it for ASDF-ification. 