### PR TITLE
Remove roman_imsim from pyproject.toml; bump postgres version to 17 in dockerfiles

### DIFF
--- a/changes/205.snappl.rst
+++ b/changes/205.snappl.rst
@@ -1,0 +1,1 @@
+Specific commit of roman_imsim in pyproject.toml; bump dockerfiles to postgres-17 and base on debian trixie (current stable).

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -5,7 +5,7 @@
 #   DOCKER_BUILDKIT=1 docker build --target postgres -t registry.nersc.gov/m4385/rknop/snpit-db-postgres:rknop-dev .
 #
 
-FROM debian:bookworm-20250630 AS base
+FROM debian:trixie-20260623 AS base
 LABEL maintainer="Rob Knop <raknop@lbl.gov>"
 
 SHELL ["/bin/bash", "-c"]
@@ -13,9 +13,9 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update \
   && DEBIAN_FRONTEND="nointeractive" apt-get -y upgrade \
   && DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get -y install -y --no-install-recommends \
-      postgresql-15 postgresql-client-15 pgtop libssl3 libreadline8 zlib1g netcat-openbsd \
+      postgresql-17 postgresql-client-17 pgtop libssl3 libreadline8 zlib1g netcat-openbsd \
       libzstd1 liblz4-1 \
-      tmux emacs-nox less procps \
+      tmux emacs-nox less procps flex \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -31,8 +31,8 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
 
-RUN echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/15/main/pg_hba.conf
-COPY postgresql.conf /etc/postgresql/15/main/postgresql.conf
+RUN echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/17/main/pg_hba.conf
+COPY postgresql.conf /etc/postgresql/17/main/postgresql.conf
 ENV POSTGRES_DATA_DIR=/var/lib/postgresql/data
 
 ENV LESS=-XLRi
@@ -46,17 +46,17 @@ WORKDIR /build
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get -y install -y --no-install-recommends \
       make git gcc libssl-dev libreadline-dev zlib1g-dev libzstd-dev liblz4-dev curl \
-      postgresql-server-dev-15 ca-certificates pkg-config
+      postgresql-server-dev-17 ca-certificates pkg-config
 
 RUN git clone https://github.com/segasai/q3c.git
 RUN cd q3c \
   && make \
   && make install
 
-RUN curl -L https://github.com/ossc-db/pg_hint_plan/archive/refs/tags/REL15_1_5_1.tar.gz \
-         -o pg_hint_plan-REL15_1_5_1.tar.gz \
-  && tar -xpf pg_hint_plan-REL15_1_5_1.tar.gz \
-  && cd pg_hint_plan-REL15_1_5_1 \
+RUN curl -L https://github.com/ossc-db/pg_hint_plan/archive/refs/tags/REL17_1_7_1.tar.gz \
+         -o pg_hint_plan-REL17_1_7_1.tar.gz \
+  && tar -xpf pg_hint_plan-REL17_1_7_1.tar.gz \
+  && cd pg_hint_plan-REL17_1_7_1 \
   && make \
   && make install
 
@@ -71,10 +71,10 @@ RUN curl -L https://github.com/ossc-db/pg_hint_plan/archive/refs/tags/REL15_1_5_
 # ENV PGRX_VERSION=0.14.1
 # RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain stable -y
 # RUN cargo install --locked cargo-pgrx --version ${PGRX_VERSION}
-# RUN cargo pgrx init --pg15 $(which pg_config)
+# RUN cargo pgrx init --pg17 $(which pg_config)
 #
-# RUN mkdir -p ~/.pgrx/data-15 \
-#   && echo "shared_preload_libraries = 'pg_parquet'" >> ~/.pgrx/data-15/postgresql.conf
+# RUN mkdir -p ~/.pgrx/data-17 \
+#   && echo "shared_preload_libraries = 'pg_parquet'" >> ~/.pgrx/data-17/postgresql.conf
 # RUN cd /opt/rust \
 #   && curl -LOJ https://github.com/CrunchyData/pg_parquet/archive/refs/tags/v${PG_PARQUET_VERSION}.tar.gz \
 #   && tar -xvzf pg_parquet-${PG_PARQUET_VERSION}.tar.gz \
@@ -88,16 +88,16 @@ RUN chown postgres -R /usr/share/postgresql/ \
 # ======================================================================
 FROM base AS postgres
 
-COPY --from=build /usr/lib/postgresql/15/lib/q3c.so /usr/lib/postgresql/15/lib/q3c.so
-COPY --from=build /usr/lib/postgresql/15/lib/bitcode/q3c /usr/share/postgresql/lib/bitcode/q3c
-COPY --from=build /usr/lib/postgresql/15/lib/bitcode/q3c.index.bc /usr/share/postgresql/lib/bitcode/q3c.index.bc
-COPY --from=build /usr/share/postgresql/15/extension/q3c* /usr/share/postgresql/15/extension/
-COPY --from=build /usr/lib/postgresql/15/lib/pg_hint_plan.so usr/lib/postgresql/15/lib/pg_hint_plan.so
-COPY --from=build /usr/lib/postgresql/15/lib/bitcode/pg_hint_plan /usr/share/postgresql/lib/bitcode/pg_hint_plan
-COPY --from=build /usr/lib/postgresql/15/lib/bitcode/pg_hint_plan.index.bc /usr/share/postgresql/lib/bitcode/pg_hint_plan.index.bc
-COPY --from=build /usr/share/postgresql/15/extension/pg_hint_plan* /usr/share/postgresql/15/extension/
-# COPY --from=build /usr/lib/postgresql/15/lib/pg_parquet.so /usr/lib/postgresql/15/lib/
-# COPY --from=build /usr/share/postgresql/15/extension/pg_parquet* /usr/share/postgresql/15/extension/
+COPY --from=build /usr/lib/postgresql/17/lib/q3c.so /usr/lib/postgresql/17/lib/q3c.so
+COPY --from=build /usr/lib/postgresql/17/lib/bitcode/q3c /usr/share/postgresql/lib/bitcode/q3c
+COPY --from=build /usr/lib/postgresql/17/lib/bitcode/q3c.index.bc /usr/share/postgresql/lib/bitcode/q3c.index.bc
+COPY --from=build /usr/share/postgresql/17/extension/q3c* /usr/share/postgresql/17/extension/
+COPY --from=build /usr/lib/postgresql/17/lib/pg_hint_plan.so usr/lib/postgresql/17/lib/pg_hint_plan.so
+COPY --from=build /usr/lib/postgresql/17/lib/bitcode/pg_hint_plan /usr/share/postgresql/lib/bitcode/pg_hint_plan
+COPY --from=build /usr/lib/postgresql/17/lib/bitcode/pg_hint_plan.index.bc /usr/share/postgresql/lib/bitcode/pg_hint_plan.index.bc
+COPY --from=build /usr/share/postgresql/17/extension/pg_hint_plan* /usr/share/postgresql/17/extension/
+# COPY --from=build /usr/lib/postgresql/17/lib/pg_parquet.so /usr/lib/postgresql/17/lib/
+# COPY --from=build /usr/share/postgresql/17/extension/pg_parquet* /usr/share/postgresql/17/extension/
 
 # Make sure this matches what is in the config file (created just above)
 # (There is some futzing about here to make sure the right permissions are

--- a/docker/postgres/postgresql.conf
+++ b/docker/postgres/postgresql.conf
@@ -41,13 +41,13 @@
 
 data_directory = '/var/lib/postgresql/data'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/15/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/17/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/15/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/17/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/15-main.pid'			# write an extra PID file
+external_pid_file = '/var/run/postgresql/17-main.pid'			# write an extra PID file
 					# (change requires restart)
 
 
@@ -611,7 +611,7 @@ log_timezone = 'Etc/UTC'
 # PROCESS TITLE
 #------------------------------------------------------------------------------
 
-cluster_name = '15/main'			# added to process titles if nonempty
+cluster_name = '17/main'			# added to process titles if nonempty
 					# (change requires restart)
 #update_process_title = on
 

--- a/docker/postgres/run_postgres.sh
+++ b/docker/postgres/run_postgres.sh
@@ -2,8 +2,8 @@
 
 if [ ! -f $POSTGRES_DATA_DIR/PG_VERSION ]; then
     echo "Running initdb in $POSTGRES_DATA_DIR"
-    /usr/lib/postgresql/15/bin/initdb -U postgres --pwfile=${PGPASSWDFILE:-/secrets/pgpasswd} $POSTGRES_DATA_DIR
-    /usr/lib/postgresql/15/bin/pg_ctl -D $POSTGRES_DATA_DIR start
+    /usr/lib/postgresql/17/bin/initdb -U postgres --pwfile=${PGPASSWDFILE:-/secrets/pgpasswd} $POSTGRES_DATA_DIR
+    /usr/lib/postgresql/17/bin/pg_ctl -D $POSTGRES_DATA_DIR start
     psql --command "CREATE DATABASE roman_snpit OWNER postgres"
     psql --command "CREATE EXTENSION q3c" roman_snpit
     psql --command "CREATE EXTENSION pgcrypto" roman_snpit
@@ -14,6 +14,6 @@ if [ ! -f $POSTGRES_DATA_DIR/PG_VERSION ]; then
     psql --command "GRANT CONNECT ON DATABASE roman_snpit TO postgres_ro"
     psql --command "GRANT USAGE ON SCHEMA public TO postgres_ro" roman_snpit
     psql --command "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO postgres_ro" roman_snpit
-    /usr/lib/postgresql/15/bin/pg_ctl -D $POSTGRES_DATA_DIR stop
+    /usr/lib/postgresql/17/bin/pg_ctl -D $POSTGRES_DATA_DIR stop
 fi
-exec /usr/lib/postgresql/15/bin/postgres -c config_file=/etc/postgresql/15/main/postgresql.conf
+exec /usr/lib/postgresql/17/bin/postgres -c config_file=/etc/postgresql/17/main/postgresql.conf

--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -7,7 +7,7 @@
 
 # ======================================================================
 
-FROM debian:trixie-20260112 AS base
+FROM debian:trixie-20260623 AS base
 LABEL maintainer="Rob Knop <rknop@pobox.com>"
 
 SHELL ["/bin/bash", "-c"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
   "pyyaml>=6.0.3,<7.0.0",
   "rkwebutil>=2.5.2,<3.0.0",
   "roman-datamodels>=1.0.0,<2.0.0",
-  "roman_imsim @ git+https://github.com/matroxel/roman_imsim.git@21ea15a",
   "scipy>=1.16.2,<2.0.0",
   "simplejson>=3.20.2,<4.0.0",
   "stpsf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "pyyaml>=6.0.3,<7.0.0",
   "rkwebutil>=2.5.2,<3.0.0",
   "roman-datamodels>=1.0.0,<2.0.0",
-  "roman_imsim @ git+https://github.com/matroxel/roman_imsim.git",
+  "roman_imsim @ git+https://github.com/matroxel/roman_imsim.git@21ea15a",
   "scipy>=1.16.2,<2.0.0",
   "simplejson>=3.20.2,<4.0.0",
   "stpsf",


### PR DESCRIPTION
Alas, having the git dependency for `roman_imsim` in `pyproject.toml` makes PyPi refuse to accept the upload of a snappl package.  So, we'll just have to document that this is a manual needed requirement.  The Dockerfiles already install it.